### PR TITLE
Make ShipwrightBuild cluster-scoped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,25 @@ jobs:
           run: make manager
         - name: Test
           run: make test
+    verify:
+        strategy:
+          matrix:
+            go-version: [1.15.x]
+            os: [ubuntu-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+        - name: Install Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: ${{ matrix.go-version }}
+        - name: Check out code
+          uses: actions/checkout@v2
+        - name: Verify fmt
+          run: make verify-fmt
+        - name: Verify generated code
+          run: make verify-generate
+        - name: Verify generated manifests
+          run: make verify-manifests
+        - name: Verify OLM bundle
+          run: make verify-bundle
+

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize:
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+operator-sdk:
+	hack/install-operator-sdk.sh $(OPERATOR_SDK)
+
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
@@ -138,11 +142,11 @@ endef
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: manifests kustomize
-	operator-sdk generate kustomize manifests -q
+bundle: manifests kustomize operator-sdk
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Verify bundle manifests were generated and committed to git
 verify-bundle: bundle

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,17 @@ manifests: controller-gen
 	# This can be removed when operator-sdk is upgraded to v1.5.x
 	hack/fix-plurals.sh
 
+# Verify manifests were generated and committed to git
+verify-manifests: manifests
+	hack/check-git-status.sh manifests
+
 # Run go fmt against code
 fmt:
 	go fmt ./...
+
+# Verify formatting and ensure git status is clean
+verify-fmt: fmt
+	hack/check-git-status.sh fmt
 
 # Run go vet against code
 vet:
@@ -91,6 +99,10 @@ vet:
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+# Verify code was generated and git status is clean
+verify-generate: generate
+	hack/check-git-status.sh generate
 
 # Build the container image
 image-build: test
@@ -131,6 +143,10 @@ bundle: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
+
+# Verify bundle manifests were generated and committed to git
+verify-bundle: bundle
+	hack/check-git-status.sh bundle
 
 # Build the bundle image.
 .PHONY: bundle-build

--- a/api/v1alpha1/shipwrightbuild_types.go
+++ b/api/v1alpha1/shipwrightbuild_types.go
@@ -27,6 +27,7 @@ type ShipwrightBuildStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
 
 // ShipwrightBuild is the Schema for the shipwrightbuilds API

--- a/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/bundle/manifests/operator.shipwright.io_shipwrightbuilds.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: ShipwrightBuildList
     plural: shipwrightbuilds
     singular: shipwrightbuild
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/config/crd/bases/operator.shipwright.io_shipwrightbuilds.yaml
+++ b/config/crd/bases/operator.shipwright.io_shipwrightbuilds.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: ShipwrightBuildList
     plural: shipwrightbuilds
     singular: shipwrightbuild
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/hack/check-git-status.sh
+++ b/hack/check-git-status.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e
+
+fixCommand="$*"
+
+if [[ -n $(git status --porcelain) ]]; then
+    echo "Verify check failed - run \`make ${fixCommand}\` and commit the resulting changes to git."
+    exit 1
+fi

--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+set -e
+
+dest=${1:-bin/operator-sdk}
+curl -sL -o "${dest}" https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2/operator-sdk_linux_amd64
+chmod +x "${dest}"


### PR DESCRIPTION
# Changes

- Make `ShipwrightBuild` a cluster-scoped CRD
- Add verification checks to ensure artifacts are correctly generated.

/kind feature

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
