### PR TITLE
Add e2e test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           run: make verify-manifests
         - name: Verify OLM bundle
           run: make verify-bundle
-    e2e:
+    e2e-operator:
         strategy:
           fail-fast: false
           matrix:
@@ -60,5 +60,24 @@ jobs:
             go-version: ${{ matrix.go-version }}
         - name: Check out code
           uses: actions/checkout@v2
-        - name: Build Image
-          run: make ko-publish IMAGE_REPO=ko.local
+        - name: Install kubectl
+          uses: azure/setup-kubectl@v1
+          with:
+            version: ${{ matrix.kubernetes }}
+        - name: Create kind cluster
+          uses: helm/kind-action@v1.1.0
+          with:
+            version: v0.10.0
+            node_image: kindest/node:${{ matrix.kubernetes }}
+            cluster_name: kind
+            wait: 120s
+        - name: Verify kind cluster
+          run: |
+            echo "# Using KinD context..."
+            kubectl config use-context "kind-kind"
+            echo "# KinD nodes:"
+            kubectl get nodes
+        - name: Test operator e2e
+          run: |
+            export KUBECONFIG=$HOME/.kube/config
+            make test-e2e-operator IMAGE_REPO=kind.local

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        image: controller:latest
+        image: controller
         name: operator
         securityContext:
           allowPrivilegeEscalation: false

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -46,17 +46,27 @@ If pushing to an external image registry, you may need to provide credentials to
 
 ```bash
 $ make ko
-$ ko login <IMAGE_REGISTRY> -u <USERNAME> -p <PASSWORD>
+$ bin/ko login <IMAGE_REGISTRY> -u <USERNAME> -p <PASSWORD>
 ```
 
-Next, build the operator image as specified above, and push to a container registry that can be accessed by the cluster:
+Next, use the ko-deploy make target to deploy to Kubernetes:
 
 ```bash
-$ make build IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" TAG="<TAG>"
+$ make ko-deploy IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" TAG="<TAG>"
 ```
 
-Finally, use the `make deploy` command with appropriate `IMAGE_REPO` and `TAG` arguments to deploy to the cluster.
+If deploying to a local KinD cluster, use `IMAGE_REPO=kind.local` and `TAG=latest`.
 
-```bash
-$ make deploy IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" TAG="<TAG>"
-```
+*Note: this will result in changes to `kustomization.yaml` files.*
+*Do not check these changes into git unless you intend to change how the operator is bundled for OLM.*
+
+## Testing your changes
+
+Before submitting a pull request, it is best practice to run our unit and end-to-end test suite against your changes.
+
+To run the unit tests, run `make test`
+
+To run the end to end tests, do the following:
+
+1. Deploy the operator to your kubernetes cluster (see above)
+2. Run `make test-e2e`

--- a/hack/test-with-envtest.sh
+++ b/hack/test-with-envtest.sh
@@ -11,4 +11,4 @@ source "${ENVTEST_ASSETS_DIR}/setup-envtest.sh"
 fetch_envtest_tools "${ENVTEST_ASSETS_DIR}"
 setup_envtest_env "${ENVTEST_ASSETS_DIR}"
 # Run tests sequentially - the controller integration tests cannot be run concurrently
-go test ./... -coverprofile cover.out -p 1
+go test ./api/... ./cmd/... ./controllers/... -coverprofile cover.out -p 1

--- a/test/common.go
+++ b/test/common.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,7 +47,6 @@ func EventuallyRemoved(ctx context.Context, k8sClient client.Client, obj client.
 			return true
 		}
 		o.Expect(err).NotTo(o.HaveOccurred())
-		fmt.Printf("found object %s: %s\n", obj.GetObjectKind(), key)
 		return false
 	}).Should(o.BeTrue())
 }

--- a/test/e2e/default_test.go
+++ b/test/e2e/default_test.go
@@ -1,0 +1,188 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/shipwright-io/operator/api/v1alpha1"
+	"github.com/shipwright-io/operator/test"
+)
+
+var _ = Describe("Reconcile default ShipwrightBuild installation", func() {
+
+	var build *v1alpha1.ShipwrightBuild
+
+	BeforeEach(func() {
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "shipwright-build",
+			},
+		}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: namespace.Name}, namespace)
+		if errors.IsNotFound(err) {
+			err = k8sClient.Create(ctx, namespace, &client.CreateOptions{})
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a ShipwrightBuild instance")
+		build = &v1alpha1.ShipwrightBuild{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Spec: v1alpha1.ShipwrightBuildSpec{},
+		}
+		err = k8sClient.Create(ctx, build, &client.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			deployment, err := getOperatorDeployment(ctx, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			logf.Log.WithValues("deployment", deployment).Info("operator deployment state")
+		}
+		By("deleting the ShipwrightBuild instance")
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: build.Name}, build)
+		if errors.IsNotFound(err) {
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.Delete(ctx, build, &client.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("checking that the shipwright-build deployment has been removed")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shipwright-build-controller",
+				Namespace: "shipwright-build",
+			},
+		}
+		test.EventuallyRemoved(ctx, k8sClient, deployment)
+	})
+
+	When("a ShipwrightBuild object is created", func() {
+
+		It("creates RBAC for the Shipwright build controller", func() {
+			expectedClusterRole := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shipwright-build-controller",
+				},
+			}
+			test.EventuallyExists(ctx, k8sClient, expectedClusterRole)
+
+			expectedClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shipwright-build-controller",
+				},
+			}
+			test.EventuallyExists(ctx, k8sClient, expectedClusterRoleBinding)
+
+			expectedServiceAccount := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shipwright-build",
+					Name:      "shipwright-build-controller",
+				},
+			}
+			test.EventuallyExists(ctx, k8sClient, expectedServiceAccount)
+		})
+
+		It("creates a deployment for the Shipwright build controller", func() {
+			expectedDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shipwright-build",
+					Name:      "shipwright-build-controller",
+				},
+			}
+			test.EventuallyExists(ctx, k8sClient, expectedDeployment)
+		})
+
+		It("creates custom resource definitions for the Shipwright build APIs", func() {
+			test.CRDEventuallyExists(ctx, k8sClient, "builds.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "buildruns.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "buildstrategies.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "clusterbuildstrategies.shipwright.io")
+		})
+	})
+
+	When("a ShipwrightBuild object is deleted", func() {
+
+		It("deletes the RBAC for the Shipwright build controller", func() {
+			expectedClusterRole := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shipwright-build-controller",
+				},
+			}
+			expectedClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shipwright-build-controller",
+				},
+			}
+			expectedServiceAccount := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shipwright-build",
+					Name:      "shipwright-build-controller",
+				},
+			}
+
+			// Setup - ensure the objects we want exist
+			test.EventuallyExists(ctx, k8sClient, expectedClusterRole)
+			test.EventuallyExists(ctx, k8sClient, expectedClusterRoleBinding)
+			test.EventuallyExists(ctx, k8sClient, expectedServiceAccount)
+
+			// Test - delete the ShipwrightBuild instance
+			err := k8sClient.Delete(ctx, build, &client.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify - check the behavior
+			test.EventuallyRemoved(ctx, k8sClient, expectedClusterRole)
+			test.EventuallyRemoved(ctx, k8sClient, expectedClusterRoleBinding)
+			test.EventuallyRemoved(ctx, k8sClient, expectedServiceAccount)
+		})
+
+		It("deletes the deployment for the Shipwright build controller", func() {
+			expectedDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shipwright-build",
+					Name:      "shipwright-build-controller",
+				},
+			}
+			// Setup - ensure the objects we want exist
+			test.EventuallyExists(ctx, k8sClient, expectedDeployment)
+
+			// Test - delete the ShipwrightBuild instance
+			err := k8sClient.Delete(ctx, build, &client.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify - check the behavior
+			test.EventuallyRemoved(ctx, k8sClient, expectedDeployment)
+		})
+
+		// TODO: Do not delete the CRDs! This is something only a cluster admin should do.
+		It("deletes the custom resource definitions for the Shipwright build APIs", func() {
+			test.CRDEventuallyExists(ctx, k8sClient, "builds.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "buildruns.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "buildstrategies.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "clusterbuildstrategies.shipwright.io")
+
+			// Test - delete the ShipwrightBuild instance
+			err := k8sClient.Delete(ctx, build, &client.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify - check the behavior
+			test.CRDEventuallyRemoved(ctx, k8sClient, "builds.shipwright.io")
+			test.CRDEventuallyRemoved(ctx, k8sClient, "buildruns.shipwright.io")
+			test.CRDEventuallyRemoved(ctx, k8sClient, "buildstrategies.shipwright.io")
+			test.CRDEventuallyRemoved(ctx, k8sClient, "clusterbuildstrategies.shipwright.io")
+		})
+	})
+
+})

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func waitForOperator(ctx context.Context, client client.Client) error {
+	var err error
+	Eventually(func() bool {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "operator-controller-manager",
+				Namespace: "shipwright-operator",
+			},
+		}
+		err = client.Get(ctx,
+			types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name},
+			deployment)
+		if errors.IsNotFound(err) {
+			return false
+		}
+		if err != nil {
+			// Break out early, return an error
+			return true
+		}
+		return deployment.Status.AvailableReplicas > 0 && deployment.Status.UpdatedReplicas > 0
+	}).Should(BeTrue())
+
+	return err
+}
+
+func getOperatorDeployment(ctx context.Context, k8sClient client.Client) (*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-controller-manager",
+			Namespace: "shipwright-operator",
+		},
+	}
+	err := k8sClient.Get(ctx,
+		types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name},
+		deployment)
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	return deployment, err
+}
+
+func getOperatorDeploymentJSON(ctx context.Context, k8sClient client.Client) (string, error) {
+	deployment, err := getOperatorDeployment(ctx, k8sClient)
+	if err != nil {
+		return "", err
+	}
+	if deployment == nil {
+		return "", nil
+	}
+	prettyJSON, err := json.MarshalIndent(deployment, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(prettyJSON), nil
+}
+
+func getOperatorPods(ctx context.Context, k8sClient client.Client) (*corev1.PodList, error) {
+	pods := &corev1.PodList{}
+	err := k8sClient.List(ctx, pods, client.InNamespace("shipwright-operator"))
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	return pods, err
+}
+
+func getOperatorPodsJSON(ctx context.Context, k8sClient client.Client) (string, error) {
+	pods, err := getOperatorPods(ctx, k8sClient)
+	if err != nil {
+		return "", err
+	}
+	if pods == nil {
+		return "", nil
+	}
+	prettyJSON, err := json.MarshalIndent(pods, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(prettyJSON), nil
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,96 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	. "github.com/onsi/gomega"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	operatorv1alpha1 "github.com/shipwright-io/operator/api/v1alpha1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var ctx context.Context
+var testEnv *envtest.Environment
+var restTimeout = 5 * time.Minute
+var restRetry = 1 * time.Second
+var log logr.Logger
+
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	SetDefaultEventuallyTimeout(restTimeout)
+	SetDefaultEventuallyPollingInterval(restRetry)
+	config.DefaultReporterConfig.SlowSpecThreshold = (1 * time.Minute).Seconds()
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Operator e2e",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	log = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(log)
+
+	By("setting up KUBECONFIG")
+	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = operatorv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = apiextv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	ctx = ctrl.SetupSignalHandler()
+
+	By("waiting for operator to be deployed")
+	err = waitForOperator(ctx, k8sClient)
+	Expect(err).NotTo(HaveOccurred())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("dumping operator deployment state")
+	deploymentJSON, err := getOperatorDeploymentJSON(ctx, k8sClient)
+	if err != nil {
+		log.Error(err, "failed to get operator deployment")
+		return
+	}
+	log.Info(fmt.Sprintf("operator deployment state: %s", deploymentJSON))
+	podsJSON, err := getOperatorPodsJSON(ctx, k8sClient)
+	if err != nil {
+		log.Error(err, "failed to get operator pods")
+	}
+	log.Info(fmt.Sprintf("operator pods state: %s", podsJSON))
+})


### PR DESCRIPTION
# Changes

- Copied current integration tests so they can be run against a real k8s
cluster. This sets the stage for full end to end testing.
- Add GitHub action job to run e2e tests on a KinD cluster
- Add make target to install ginkgo cli
- Use ko to deploy to Kubernetes. Add instructions on how to deploy with `make ko-deploy`.

/kind documentation

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
