### PR TITLE
Alternative GNU Sed Location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ testbin/*
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia
+.env
 .idea
 *.swp
 *.swo

--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,12 @@ undeploy:
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
+SED_BIN ?= sed
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	# Fix pluralization of ShipwrightBuilds in generated manifests
 	# This can be removed when operator-sdk is upgraded to v1.5.x
-	hack/fix-plurals.sh
+	SED_BIN=${SED_BIN} hack/fix-plurals.sh
 
 # Verify manifests were generated and committed to git
 verify-manifests: manifests

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -28,7 +28,7 @@ The following make options can be set:
 * `TAG` - defaults to `latest`.
 * `IMAGE_PUSH` - if false, does not push the image. Defaults to true.
 
-Refer to the [ko documenation](https://github.com/google/ko#local-publishing-options) for more information.
+Refer to the [ko documentation](https://github.com/google/ko#local-publishing-options) for more information.
 
 ## Deploy to Kubernetes
 
@@ -59,4 +59,10 @@ Finally, use the `make deploy` command with appropriate `IMAGE_REPO` and `TAG` a
 
 ```bash
 $ make deploy IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" TAG="<TAG>"
+```
+
+Scripts in `hack` folder may require `sed` (GNU), therefore in platforms other than Linux you may have it with a different name. For instance, on macOS it's usually named `gsed`, in this case provide the `SED_BIN` make variable with the alternative name.
+
+```bash
+$ make build SED_BIN=gsed ...
 ```

--- a/hack/fix-plurals.sh
+++ b/hack/fix-plurals.sh
@@ -1,8 +1,12 @@
-#! /bin/bash
-
+#!/bin/bash
+#
 # Script to work around https://github.com/operator-framework/operator-sdk/issues/4453
+#
 
 set -e
 
-sed -i 's/shipwrightbuildren/shipwrightbuilds/' config/crd/bases/operator.shipwright.io_shipwrightbuildren.yaml
+# allowing sed binary customization, so macos users can use an alternative gnu/sed, usually named "gsed"
+SED_BIN="${SED_BIN:-sed}"
+
+${SED_BIN} -i 's/shipwrightbuildren/shipwrightbuilds/' config/crd/bases/operator.shipwright.io_shipwrightbuildren.yaml
 mv -f config/crd/bases/operator.shipwright.io_shipwrightbuildren.yaml config/crd/bases/operator.shipwright.io_shipwrightbuilds.yaml


### PR DESCRIPTION
# Changes

Allowing users to export `SED_BIN` environment variable, so macOS users can use `gsed` instead. Plus, a few other minor changes.

# Submitter Checklist

- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```