### PR TITLE
Multi-Platform Scripts

### DIFF
--- a/hack/install-ko.sh
+++ b/hack/install-ko.sh
@@ -1,8 +1,36 @@
-#! /bin/bash
+#!/usr/bin/env bash
+#
+# Installs ko in the informed location, by downloading and extracting tarball in place.
+#
+# $ install-ko.sh "bin/ko"
+#
 
 set -e
 
-dest=${1:-bin}
-mkdir -p "${dest}"
-curl -fsL https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - -C "${dest}" ko
-chmod +x "${dest}/ko"
+DEST="${1:-bin/ko}"
+KO_VERSION="${KO_VERSION:-0.8.1}"
+
+OS="${OS:-linux}"
+ARCH="${ARCH:-amd64}"
+
+# making amendments to the way ko releases are named, more architectures may be added later on
+if [ $ARCH == "amd64" ] ; then
+    ARCH="x86_64"
+fi
+# operational system name is capitalized
+OS="${OS^}"
+
+KO_URL_HOST="${KO_HOST:-github.com}"
+KO_URL_PATH="${KO_URL_PATH:-google/ko/releases/download}"
+KO_URL="https://${KO_URL_HOST}/${KO_URL_PATH}/v${KO_VERSION}/ko_${KO_VERSION}_${OS}_${ARCH}.tar.gz"
+
+if [ -x ${DEST} ] ; then
+    echo "# ko is already installed at '${DEST}'"
+    exit 0
+fi
+
+BASE_DIR="$(dirname ${DEST})"
+
+curl --fail --silent --location "${KO_URL}" \
+    |tar xzf - -C ${BASE_DIR} ko
+chmod +x "${DEST}"

--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -1,7 +1,27 @@
-#! /bin/bash
+#!/usr/bin/env bash
+#
+# Download and copy opeartor-sdk to the desired location. The target location is specified by the
+# first argument. For instance:
+#
+# $ install-operator-sdk.sh "bin/operator-sdk"
+#
 
 set -e
 
-dest=${1:-bin/operator-sdk}
-curl -sL -o "${dest}" https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2/operator-sdk_linux_amd64
-chmod +x "${dest}"
+DEST="${1:-bin/operator-sdk}"
+SDK_VERSION="${SDK_VERSION:-1.4.2}"
+
+OS="${OS:-linux}"
+ARCH="${ARCH:-amd64}"
+
+SDK_URL_HOST="${SDK_HOST:-github.com}"
+SDK_URL_PATH="${SDK_URL_PATH:-operator-framework/operator-sdk/releases/download}"
+SDK_URL="https://${SDK_URL_HOST}/${SDK_URL_PATH}/v${SDK_VERSION}/operator-sdk_${OS}_${ARCH}"
+
+if [ -x ${DEST} ] ; then
+    echo "# operator-sdk is already installed at '${DEST}'"
+    exit 0
+fi
+
+curl --silent --location --output "${DEST}" "${SDK_URL}"
+chmod +x "${DEST}"


### PR DESCRIPTION
# Changes

Exporting `OS` and `ARCH` variables through `Makefile` targets, so `hack/` scripts can be executed on more platforms than "Linux/amd64".

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```