### PR TITLE
 E2E CI Test for Operator Bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             go-version: [1.15.x]
             os: [ubuntu-latest]
             kubernetes:
-              - v1.19.7
+              - v1.20.7
           max-parallel: 2
         runs-on: ${{ matrix.os }}
         steps:
@@ -60,5 +60,35 @@ jobs:
             go-version: ${{ matrix.go-version }}
         - name: Check out code
           uses: actions/checkout@v2
-        - name: Build Image
-          run: make ko-publish IMAGE_REPO=ko.local
+        - name: Install kubectl
+          uses: azure/setup-kubectl@v1
+          with:
+            version: ${{ matrix.kubernetes }}
+        - name: Deploy KinD Local Container Registry
+          run: make deploy-kind-registry
+        - name: Create KinD cluster
+          uses: helm/kind-action@v1.2.0
+          with:
+            version: v0.11.1
+            node_image: kindest/node:${{ matrix.kubernetes }}
+            cluster_name: kind
+            config: test/kind/config.yaml
+            wait: 120s
+        - name: Verify KinD cluster
+          run: make verify-kind
+        - name: Install KinD post-actions
+          run: make deploy-kind-registry-post
+        - name: Install OLM
+          run: make install-olm
+        # Builds the operator and makes the image readable in the KinD cluster
+        - name: Build Operator Image
+          run: |
+            make ko-publish IMAGE_REPO=localhost:5000
+        - name: Build Operator Bundle
+          run: |
+            make bundle-push IMAGE_REPO=localhost:5000
+        - name: Build Catalog Source
+          run: |
+            make catalog-push IMAGE_REPO=localhost:5000
+        - name: Run Operator with Catalog
+          run: make catalog-run IMAGE_REPO=localhost:5000

--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,21 @@ IMAGE_REPO ?= quay.io/shipwright
 TAG ?= $(VERSION)
 IMAGE_PUSH ?= true
 
-BUNDLE_IMG_NAME ?= operator-bundle
-OPERATOR_IMG_NAME ?= operator
+IMAGE_TAG_BASE ?= $(IMAGE_REPO)/operator
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_REPO)/$(OPERATOR_IMG_NAME):$(TAG)
+IMG ?= $(IMAGE_TAG_BASE):$(TAG)
 
 # BUNDLE_IMG defines the image:tag used for the bundle. 
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_REPO)/$(BUNDLE_IMG_NAME):$(TAG)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(TAG)
 
 # operating-system type and architecture based on golang
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
+
+KUBECTL_BIN ?= kubectl
+SED_BIN ?= sed
 
 all: operator
 
@@ -76,23 +78,22 @@ run: generate fmt vet manifests
 
 # Install CRDs into a cluster
 install: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL_BIN) apply -f -
 
 # Uninstall CRDs from a cluster
 uninstall: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL_BIN) delete -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller="$(IMG)"
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL_BIN) apply -f -
 
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
 undeploy:
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL_BIN) delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
-SED_BIN ?= sed
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
@@ -185,6 +186,11 @@ bundle-build: bundle
 bundle-push: bundle-build
 	$(CONTAINER_ENGINE) push $(BUNDLE_IMG)
 
+# Install OLM on the current cluster
+.PHONY: install-olm
+install-olm: operator-sdk
+	$(OPERATOR_SDK) olm install
+
 .PHONY: opm
 OPM = ./bin/opm
 opm:
@@ -202,12 +208,42 @@ endif
 endif
 
 BUNDLE_IMGS ?= $(BUNDLE_IMG) 
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION) ifneq ($(origin CATALOG_BASE_IMG), undefined) FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG) endif 
+CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(VERSION)
 
+#
+# ifneq ($(origin CATALOG_BASE_IMG), undefined) 
+# FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
+# endif
+# $(OPM) index add --container-tool $(CONTAINER_ENGINE) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+
+CATALOG_INDEX_IMG ?= quay.io/operatorhubio/catalog:latest
+
+# Build a catalog image with the operator bundle included
 .PHONY: catalog-build
 catalog-build: opm
-	$(OPM) index add --container-tool $(CONTAINER_ENGINE) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
+	$(OPM) index add --container-tool $(CONTAINER_ENGINE) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) --from-index=$(CATALOG_INDEX_IMG)
+	
+# Build and push a catalog image with the operator bundle to a container registry
 .PHONY: catalog-push
-catalog-push: ## Push the catalog image.
+catalog-push: catalog-build
 	$(CONTAINER_ENGINE) push $(CATALOG_IMG)
+
+
+CATALOG_NAMESPACE ?= shipwright-operator
+
+# Run the operator from a catalog image, using an OLM subscription
+.PHONY: catalog-run
+catalog-run:
+	CATALOG_IMG=$(CATALOG_IMG) CSV_VERSION=$(VERSION) KUBECTL_BIN=$(KUBECTL_BIN) NAMESPACE=$(CATALOG_NAMESPACE) SED_BIN=$(SED_BIN) hack/run-operator-catalog.sh
+
+.PHONY: verify-kind
+verify-kind:
+	KUBECTL_BIN=$(KUBECTL_BIN) test/kind/verify-kind.sh
+
+.PHONY: deploy-kind-registry
+deploy-kind-registry:
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) KUBECTL_BIN=$(KUBECTL_BIN) test/kind/deploy-registry.sh
+
+.PHONY: deploy-kind-registry-post
+deploy-kind-registry-post:
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) KUBECTL_BIN=$(KUBECTL_BIN) test/kind/deploy-registry-post.sh

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,10 @@ CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(VERSION)
 # endif
 # $(OPM) index add --container-tool $(CONTAINER_ENGINE) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
-CATALOG_INDEX_IMG ?= quay.io/operatorhubio/catalog:latest
+# The main multi-arch operatorhub image has a bug that causes opm index add to fail.
+# This doesn't seem to be an issue for the single-arch x86 image.
+# See https://github.com/operator-framework/operator-registry/issues/870
+CATALOG_INDEX_IMG ?= quay.io/operatorhubio/catalog_sa
 
 # Build a catalog image with the operator bundle included
 .PHONY: catalog-build

--- a/config/catalog/catalog_source.yaml
+++ b/config/catalog/catalog_source.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: shipwright-operator
+  name: system
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operator
+  namespace: system
+spec:
+  sourceType: grpc
+  image: catalog-source:latest
+  displayName: Shipwright Operator Catalog
+  publisher: The Shipwright Contributors
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/config/catalog/kustomization.yaml
+++ b/config/catalog/kustomization.yaml
@@ -1,0 +1,7 @@
+namespace: shipwright-operator
+namePrefix: shipwright-
+
+resources:
+- catalog_source.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/subscription/kustomization.yaml
+++ b/config/subscription/kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: shipwright-operator
+namePrefix: shipwright-
+
+resources:
+- subscription.yaml
+- operator_group.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/subscription/operator_group.yaml
+++ b/config/subscription/operator_group.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: operator
+  namespace: system
+spec: {}

--- a/config/subscription/subscription.yaml
+++ b/config/subscription/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: operator
+  namespace: system
+spec:
+  channel: alpha
+  name: shipwright-operator
+  source: shipwright-operator
+  sourceNamespace: shipwright-operator
+  installPlanApproval: Automatic
+  startingCSV: shipwright-operator.v0.0.0

--- a/controllers/default_test.go
+++ b/controllers/default_test.go
@@ -154,7 +154,10 @@ var _ = g.Describe("Reconcile default ShipwrightBuild installation", func() {
 
 		err = k8sClient.Delete(ctx, build, &client.DeleteOptions{})
 		// the delete e2e's can delete this object before this AfterEach runs
-		o.Expect(err).To(o.BeNil(), o.MatchError(metav1.StatusReasonNotFound))
+		if errors.IsNotFound(err) {
+			return
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for ShipwrightBuild instance to be completely removed")
 		test.EventuallyRemoved(ctx, k8sClient, build)

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -34,8 +34,8 @@ Refer to the [ko documentation](https://github.com/google/ko#local-publishing-op
 
 To test the operator on a Kubernetes cluster, you first must have the following:
 
-* Access to a Kubernetes cluster v1.19 or higher, with cluster admin permissions.
-* Install Tekton v0.21 on the cluster.
+* Access to a Kubernetes cluster v1.20 or higher, with cluster admin permissions.
+* Install [Tekton operator](https://github.com/tektoncd/operator) v0.49 or higher on the cluster.
 
 ```bash
 $ export KUBECONFIG=/path/to/kubeconfig
@@ -60,6 +60,8 @@ Finally, use the `make deploy` command with appropriate `IMAGE_REPO` and `TAG` a
 ```bash
 $ make deploy IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" TAG="<TAG>"
 ```
+
+_Note:_
 
 Scripts in `hack` folder may require `sed` (GNU), therefore in platforms other than Linux you may have it with a different name. For instance, on macOS it's usually named `gsed`, in this case provide the `SED_BIN` make variable with the alternative name.
 

--- a/docs/development/olm-development.md
+++ b/docs/development/olm-development.md
@@ -1,0 +1,61 @@
+# OLM Development
+
+The Shipwright operator is meant to be deployed on a cluster using the
+[Operator Lifecycle Manager](https://olm.operatorframework.io/) (OLM).
+OLM provides mechanisms to support over the air upgrades and automatically deploy related operators
+that are packaged in operator [catalogs](https://olm.operatorframework.io/).
+Additional steps need to be taken to ensure the operator can be deployed with OLM.
+
+## Prerequisites
+
+* Ensure you have access to a Kubernetes cluster via `kubectl` with cluster admin permissions.
+* Install Go version 1.15 or higher.
+* Install OLM on your cluster. This can be done using the `make install-olm` command.
+* Ability to push to a container registry that is accessible inside your Kubernetes cluster.
+
+## Step 1: Push the operator image to a registry
+
+Run `make ko-publish IMAGE_REPO=<your-registry>`, pushing to a container registry that is accessible inside your Kubernetes cluster.
+Using `ko.local` or `kind.local` is not recommended, as this will not push the resulting image to a container registry.
+
+If you are using [KinD](https://kind.sigs.k8s.io/), follow the instructions on how to configure a
+[local registry](https://kind.sigs.k8s.io/docs/user/local-registry/).
+This will let you use `localhost:<port>` as your container registry.
+
+## Step 2: Build and push the operator bundle
+
+Next, run `make bundle-push IMAGE_REPO=<your-registry>`.
+This will push the [operator bundle](https://olm.operatorframework.io/docs/tasks/creating-operator-bundle/)
+to the container registry.
+An operator bundle is an OCI aritfact that tells OLM how to deploy your operator.
+Be sure to use the same container registry for the `IMAGE_REPO` argument.
+
+## Step 3: Build and push an operator catalog
+
+Next, run `make catalog-push IMAGE_REPO=<your-registry>`.
+This will build and push an [operator catalog](https://olm.operatorframework.io/docs/tasks/creating-a-catalog/),
+which packages your test operator bundle with the other operators available on [operatorhub.io](https://operatorhub.io).
+As in step 2, be sure to use the same container registry for the `IMAGE_REPO` argument.
+
+## Step 4: Deploy the operator using the catalog image
+
+Finally, deploy the operator using `make catalog-run IMAGE_REPO=<your-registry>`, using the same
+value for `IMAGE_REPO` as in the previous steps.
+This will run a script that does the following:
+
+1. Creates a custom [CatalogSource](https://olm.operatorframework.io/docs/tasks/make-catalog-available-on-cluster/)
+   and [OperatorGroup](https://olm.operatorframework.io/docs/advanced-tasks/operator-scoping-with-operatorgroups/),
+   which allows the operators in step 3's catalog to be installed anywhere on the clsuter.
+2. Creates a [Subscription](https://olm.operatorframework.io/docs/tasks/install-operator-with-olm/),
+   which instructs OLM to install the operator and any dependent operators.
+3. Checks that the operator has successfully been installed and rolled out.
+
+Once the script completes, the Shipwright and Tekton operators will be installed on the cluster.
+
+_Note:_
+
+Scripts in `hack` folder may require `sed` (GNU), therefore in platforms other than Linux you may have it with a different name. For instance, on macOS it's usually named `gsed`, in this case provide the `SED_BIN` make variable with the alternative name.
+
+```bash
+$ make catalog-run SED_BIN=gsed ...
+```

--- a/hack/run-operator-catalog.sh
+++ b/hack/run-operator-catalog.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# hack/run-operator-catalog.sh
+#
+# Run the operator from a catalog image.
+# Required environment variables:
+#
+# - CATALOG_IMG: catalog image to deploy
+# - CSV_VERSION: version tag of the cluster service version
+#
+# Optional environment variables
+#
+# - KUSTOMIZE_BIN: path to kustomize
+# - KUBECTL_BIN: path to kubectl (or equivalent command line)
+# - SED_BIN: path to GNU sed
+# - CATALOG_NAMESPACE: Namespace to deploy the catalog. Defaults to shipwright-operator.
+# - SUBSCRIPTION_NAMESPACE: Namespace to install the operator via an OLM subscription. Defaults to
+#   shipwright-operator.
+# - NAME_PREFIX: prefix to use for all resource names. Defaults to "shipwright-"
+
+set -eu -o pipefail
+
+KUSTOMIZE_BIN=${KUSTOMIZE_BIN:-${PWD}/bin/kustomize}
+KUBECTL_BIN=${KUBECTL_BIN:-kubectl}
+SED_BIN=${SED_BIN:-sed}
+CATALOG_NAMESPACE=${CATALOG_NAMESPACE:-shipwright-operator}
+SUBSCRIPTION_NAMESPACE=${SUBSCRIPTION_NAMESPACE:-shipwright-operator}
+NAME_PREFIX=${NAME_PREFIX:-shipwright-}
+
+if [[ -z ${CATALOG_IMG} ]]; then
+    echo "CATALOG_IMG environment variable must be set"
+    exit 1
+fi
+
+if [[ -z ${CSV_VERSION} ]]; then
+    echo "CSV_VERSION environment variable must be set"
+    exit 1
+fi
+
+function add_kustomizations() {
+    echo "Adding replacements not supported by kustomize"
+    ${SED_BIN} -i -E "s|image: (.+)$|image: ${CATALOG_IMG}|g" config/catalog/catalog_source.yaml
+    ${SED_BIN} -i -E "s|startingCSV: (.+)$|startingCSV: shipwright-operator.v${CSV_VERSION}|g" config/subscription/subscription.yaml
+    ${SED_BIN} -i -E "s|sourceNamespace: (.+)$|sourceNamespace: ${CATALOG_NAMESPACE}|g" config/subscription/subscription.yaml
+    ${SED_BIN} -i -E "s|source: (.+)$|source: ${NAME_PREFIX}operator|g" config/subscription/subscription.yaml
+
+    echo "Applying catalog source and subscription from kustomize"
+
+    pushd config/catalog
+    ${KUSTOMIZE_BIN} edit set namespace "${CATALOG_NAMESPACE}"
+    ${KUSTOMIZE_BIN} edit set nameprefix "${NAME_PREFIX}"
+    popd
+
+    pushd config/subscription
+    ${KUSTOMIZE_BIN} edit set namespace "${SUBSCRIPTION_NAMESPACE}"
+    ${KUSTOMIZE_BIN} edit set nameprefix "${NAME_PREFIX}"
+    popd
+}
+
+function dump_state() {
+    echo "Dumping OLM catalog sources"
+    ${KUBECTL_BIN} get catalogsources -n "${CATALOG_NAMESPACE}" -o yaml
+    echo "Dumping OLM subscriptions"
+    ${KUBECTL_BIN} get subscriptions -n "${SUBSCRIPTION_NAMESPACE}" -o yaml
+    echo "Dumping OLM installplans"
+    ${KUBECTL_BIN} get installplans -n "${SUBSCRIPTION_NAMESPACE}" -o yaml
+    echo "Dumping OLM CSVs"
+    ${KUBECTL_BIN} get clusterserviceversions -n "${SUBSCRIPTION_NAMESPACE}" -o yaml
+    echo "Dumping pods"
+    ${KUBECTL_BIN} get pods -n "${SUBSCRIPTION_NAMESPACE}" -o yaml
+    echo "${CATALOG_NAMESPACE} -ne ${SUBSCRIPTION_NAMESPACE}"
+    if [ "${CATALOG_NAMESPACE}" != "${SUBSCRIPTION_NAMESPACE}" ]; then
+        ${KUBECTL_BIN} get pods -n "${CATALOG_NAMESPACE}" -o yaml
+    fi
+}
+
+function wait_for_pod() {
+    label=$1
+    namespace=$2
+    timeout=$3
+    ${KUBECTL_BIN} wait --for=condition=Ready pod -l "${label}" -n "${namespace}" --timeout "${timeout}"
+}
+
+add_kustomizations
+
+echo "Deploying catalog source"
+${KUSTOMIZE_BIN} build config/catalog | ${KUBECTL_BIN} apply -f -
+
+echo "Waiting for the catalog source to be ready"
+# Wait 15 seconds for the catalog source pod to be created first.
+sleep 15
+if ! wait_for_pod "olm.catalogSource=${NAME_PREFIX}operator" "${CATALOG_NAMESPACE}" 1m; then
+    echo "Failed to deploy catalog source, dumping operator state"
+    dump_state
+    exit 1
+fi
+
+echo "Deploying subscription"
+${KUSTOMIZE_BIN} build config/subscription | ${KUBECTL_BIN} apply -f -
+
+echo "Waiting for the operator to be ready"
+# Wait 60 seconds for the operator pod to be created
+# This needs extra time due to OLM's reconciliation process
+sleep 60
+if ! wait_for_pod "app=shipwright-operator" "${SUBSCRIPTION_NAMESPACE}" 5m; then
+    echo "Failed to deploy, dumping operator state"
+    dump_state
+    exit 1
+fi
+
+exit 0

--- a/test/kind/config.yaml
+++ b/test/kind/config.yaml
@@ -1,0 +1,14 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://kind-registry:5000"]
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-admission-plugins: CertificateApproval,CertificateSigning,CertificateSubjectRestriction,DefaultIngressClass,DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,OwnerReferencesPermissionEnforcement,PersistentVolumeClaimResize,PersistentVolumeLabel,PodNodeSelector,PodTolerationRestriction,Priority,ResourceQuota,RuntimeClass,ServiceAccount,StorageObjectInUseProtection,TaintNodesByCondition,ValidatingAdmissionWebhook

--- a/test/kind/deploy-registry-post.sh
+++ b/test/kind/deploy-registry-post.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+DOCKER="${CONTAINER_ENGINE:-docker}"
+KUBECTL_BIN="${KUBECTL_BIN:-kubectl}"
+
+echo "Running KinD registry post-install actions"
+
+reg_name='kind-registry'
+
+echo "Connecting registry ${reg_name} to kind network"
+# connect the registry to the cluster network
+# (the network may already be connected)
+${DOCKER} network connect "kind" "${reg_name}" || true
+
+echo "Registry connected to kind network"
+
+echo "Publishing local container registry on the KinD cluster"
+
+${KUBECTL_BIN} apply -f test/kind/local-registry-cm.yaml
+
+echo "Done"

--- a/test/kind/deploy-registry.sh
+++ b/test/kind/deploy-registry.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eu
+
+DOCKER="${CONTAINER_ENGINE:-DOCKER}"
+
+# create registry container unless it already exists
+REG_NAME='kind-registry'
+REG_PORT='5000'
+echo "Deploying container registry ${REG_NAME}:${REG_PORT}"
+running="$(${DOCKER} inspect -f '{{.State.Running}}' "${REG_NAME}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  ${DOCKER} run \
+    -d --restart=always -p "127.0.0.1:${REG_PORT}:5000" --name "${REG_NAME}" \
+    registry:2
+fi
+
+echo "Container registry ${REG_NAME} deployed"

--- a/test/kind/local-registry-cm.yaml
+++ b/test/kind/local-registry-cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:5000"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"

--- a/test/kind/verify-kind.sh
+++ b/test/kind/verify-kind.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+set -eu
+
+KUBECTL_BIN=${KUBECTL_BIN:-kubectl}
+
+echo "# Using KinD context..."
+${KUBECTL_BIN} config use-context "kind-kind"
+echo "# KinD nodes:"
+${KUBECTL_BIN} get nodes
+
+nodeStatus=$(${KUBECTL_BIN} get node kind-control-plane -o json | jq -r .'status.conditions[] | select(.type == "Ready") | .status')
+if [ "${nodeStatus}" != "True" ]; then
+    echo "# Node is not ready:"
+    ${KUBECTL_BIN} describe node kind-control-plane
+    echo "# Pods:"
+    ${KUBECTL_BIN} get pod -A
+    echo "# Events:"
+    ${KUBECTL_BIN} get events -A
+
+    exit 1
+fi


### PR DESCRIPTION
# Changes

This change augments the e2e test suite to simulate the operator's deployment using OLM.
The setup consists of the following components:
    
- A docker/distribution container registry, running in docker outside of any Kubernetes cluster.
- A KinD cluster that is configured to resolve image refs which use "localhost" as the image registry domain.
- Installing OLM on the KinD cluster.
    
Once set up, the operator and its associated OLM bundle are built and pushed to the local container registry.
Next, an OLM catalog is built based on the catalog published in operatorhub.io.
The catalog is what allows OLM to find the Tekton operator that Shipwright depends on, and is likewise pushed to the local container registry.
    
Building the operator, bundle, and catalog with a fully on-cluster registry is problematic for several reasons:
    
- Not all tools can push to the on-cluster registry in this fashion
- Mainfests need to be rewritten to reference the on-cluster DNS name for the registry
- The catalog source needs to be pullable within the cluster.
    
The test runs as follows:
    
- Create a namespace to run the operator under test
- Create a CatalogSource using the catalog containing the operator under test.
- Create an OperatorGroup which allows AllNamespace operators to be installed in the given namespace.
- Create a Subscription to install the Shipwright operator and its associated Tekton operator.
- Verify that the shipwright operator deploys successfully.
    
See also:

- https://kind.sigs.k8s.io/docs/user/local-registry/
- https://olm.operatorframework.io/docs/tasks/creating-a-catalog/
- https://olm.operatorframework.io/docs/tasks/make-catalog-available-on-cluster/
- https://olm.operatorframework.io/docs/tasks/install-operator-with-olm/
- https://olm.operatorframework.io/docs/advanced-tasks/operator-scoping-with-operatorgroups/

/kind cleanup

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.


# Release Notes

```release-note
Add CI and developer documentation on how to deploy the operator using OLM.
```
