### PR TITLE
Run operator as non-root

### DIFF
--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -435,6 +435,8 @@ spec:
                   name: https
                   protocol: TCP
                 resources: {}
+                securityContext:
+                  runAsUser: 1000640000
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -463,7 +465,7 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:
-                runAsUser: 65532
+                runAsNonRoot: true
               serviceAccountName: shipwright-operator
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,8 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          runAsUser: 1000640000
       - name: operator
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         app: shipwright-operator
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsNonRoot: true
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
# Changes

Run operator as non-root instead of a fixed UID. This fixes issues with OpenShift security context constraints.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

/kind bug

# Release Notes

```release-note
Run operator as non-root instead of using a fixed UID. This allows the operator to run on OpenShift using the "restricted" security context constraint.
```
