### PR TITLE
Verify deployment of build controller

### DIFF
--- a/hack/run-operator-catalog.sh
+++ b/hack/run-operator-catalog.sh
@@ -108,4 +108,22 @@ if ! wait_for_pod "app=shipwright-operator" "${SUBSCRIPTION_NAMESPACE}" 5m; then
     exit 1
 fi
 
+echo "Deploying Shipwright build controller"
+
+${KUBECTL_BIN} apply -f - <<EOF
+kind: ShipwrightBuild
+apiVersion: operator.shipwright.io/v1alpha1
+metadata:
+  name: shipwright
+spec:
+    targetNamespace: ${SUBSCRIPTION_NAMESPACE}
+EOF
+
+if ! ${KUBECTL_BIN} wait --for=condition=Ready=true shipwrightbuilds.operator.shipwright.io/shipwright --timeout=5m; then
+    echo "Failed to deploy ShipwrightBuild - dumping ShipwrightBuild state"
+    ${KUBECTL_BIN} get shipwrightbuilds -o yaml
+    dump_state
+    exit 1
+fi
+
 exit 0


### PR DESCRIPTION
# Changes

Use the ShipwrightBuild object to verify we can deploy the build controller.

/kind cleanup

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```