### PR TITLE
Update operator version and image spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.7.0
+VERSION ?= 0.7.1-snapshot
 
 # CHANNELS define the bundle channels used in the bundle. 
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
@@ -35,8 +35,8 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 CONTAINER_ENGINE ?= docker
-IMAGE_HOST ?= quay.io
-IMAGE_NAMESPACE ?= shipwright
+IMAGE_HOST ?= ghcr.io
+IMAGE_NAMESPACE ?= shipwright-io/operator
 IMAGE_REPO ?= $(IMAGE_HOST)/$(IMAGE_NAMESPACE)
 TAG ?= $(VERSION)
 IMAGE_PUSH ?= true

--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/shipwright-io/operator
     support: The Shipwright Contributors
-  name: shipwright-operator.v0.7.0
+  name: shipwright-operator.v0.7.1-snapshot
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -560,7 +560,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                image: quay.io/shipwright/operator:0.7.0
+                image: ghcr.io/shipwright-io/operator/operator:0.7.1-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -648,4 +648,4 @@ spec:
   provider:
     name: The Shipwright Contributors
     url: https://shipwright.io
-  version: 0.7.0
+  version: 0.7.1-snapshot

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/shipwright/operator
-  newTag: 0.7.0
+  newName: ghcr.io/shipwright-io/operator/operator
+  newTag: 0.7.1-snapshot


### PR DESCRIPTION
# Changes

This fixes test failures due to the fact that the CSV version of the operator being tested conflicts with the operator in the OperatorHub index image.

- Update the default version to 0.7.1-snapshot so it does not conflict
  with the CSV on OperatorHub.
- Update default image location to ghcr.io so we can more easily submit
  updates to OperatorHub.

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Update default location of the operator image to ghcr.io/shipwright-io/operator/operator.
```
