### PR TITLE
Disable Catalog Build and Run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
         - name: Build Operator Bundle
           run: |
             make bundle-push IMAGE_REPO=localhost:5000
-        - name: Build Catalog Source
-          run: |
-            make catalog-push IMAGE_REPO=localhost:5000
-        - name: Run Operator with Catalog
-          run: make catalog-run IMAGE_REPO=localhost:5000
+        # - name: Build Catalog Source
+        #   run: |
+        #     make catalog-push IMAGE_REPO=localhost:5000
+        # - name: Run Operator with Catalog
+        #   run: make catalog-run IMAGE_REPO=localhost:5000


### PR DESCRIPTION
# Changes

Temporarily disabling the catalog build and run test.
This will unblock contributions that currently fail due to failures
running `opm index add`.

Stop-gap until we fully fix #57 

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```