### PR TITLE
Deploy Shipwright Build v0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.8.1-snapshot
+VERSION ?= 0.9.0-rc.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -2,15 +2,21 @@
 
 An operator to install and configure [Shipwright](https://shipwright.io) on Kubernetes clusters.
 
-## Contributing
+## Installation
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to build, test, and submit
-contributions to the operator.
+The Shipwright operator is designed to be installed with the [Operator Lifecycle Manager](https://olm.operatorframework.io/) ("OLM").
+Before installation, ensure that OLM has been deployed on your cluster by following the [OLM installation instructions](https://olm.operatorframework.io/docs/getting-started/#installing-olm-in-your-cluster).
+
+Once OLM has been deployed, use the following command to install the latest operator release from [operatorhub.io](https://operatorhub.io/operator/shipwright-operator):
+
+```sh
+$ kubectl apply -f https://operatorhub.io/install/shipwright-operator.yaml
+```
 
 ## Usage
 
 To deploy and manage [Shipwright Builds](https://github.com/shipwright-io/build) in your cluster,
-first make sure this operator is installed and running on your cluster.
+first make sure this operator is installed and running.
 
 Next, create the following:
 
@@ -26,5 +32,9 @@ spec:
 
 The operator will deploy Shipwright Builds in the provided `targetNamespace`.
 When `.spec.targetNamespace` is not set, the namespace will default to `shipwright-build`.
+Refer to the [ShipwrightBuild documentation](docs/shipwrightbuild.md) for more information about this custom resource.
 
-_Note: this namespace needs to be created before the actual deployment takes place._
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to build, test, and submit
+contributions to the operator.

--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/shipwright-io/operator
     support: The Shipwright Contributors
-  name: shipwright-operator.v0.8.1-snapshot
+  name: shipwright-operator.v0.9.0-rc.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -211,6 +211,50 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - clusterbuildstrategies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - buildstrategies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - builds
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - buildruns
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
         - apiGroups:
           - shipwright.io
           resources:
@@ -568,7 +612,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                image: ghcr.io/shipwright-io/operator/operator:0.8.1-snapshot
+                image: ghcr.io/shipwright-io/operator/operator:0.9.0-rc.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -656,4 +700,4 @@ spec:
   provider:
     name: The Shipwright Contributors
     url: https://shipwright.io
-  version: 0.8.1-snapshot
+  version: 0.9.0-rc.0

--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -63,8 +63,7 @@ spec:
 
     The operator will deploy Shipwright Builds in the provided `targetNamespace`.
     When `.spec.targetNamespace` is not set, the namespace will default to `shipwright-build`.
-
-    _Note: this namespace needs to be created before the actual deployment takes place._
+    Refer to the [ShipwrightBuild documentation](https://github.com/shipwright-io/operator/blob/main/docs/shipwrightbuild.md) for more information about this custom resource.
   displayName: Shipwright Operator
   icon:
   - base64data: |

--- a/cmd/operator/kodata/release.yaml
+++ b/cmd/operator/kodata/release.yaml
@@ -124,7 +124,7 @@ spec:
       serviceAccountName: shipwright-build-controller
       containers:
         - name: shipwright-build
-          image: ghcr.io/shipwright-io/build/shipwright-build-controller:v0.8.0@sha256:984df5f60a4c6bea68d6ae298abad4e861c6ca9b2e75432d57729bbcfbc5073f
+          image: ghcr.io/shipwright-io/build/shipwright-build-controller:v0.9.0@sha256:d0a7dcd3b6b85560c84cf80aaf5602f2ce370b672a001ab1ae5232baa3406720
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -141,15 +141,15 @@ spec:
             - name: CONTROLLER_NAME
               value: "shipwright-build"
             - name: GIT_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/git:v0.8.0@sha256:0ade6417b6ae41fc9adc191b56cd4284915abdb3849a5669a4efb018dc054d2b
+              value: ghcr.io/shipwright-io/build/git:v0.9.0@sha256:8d0f29e80440095f7652a8a19ec22f2db9d9c93e5525558d58bf2fab5ec085fe
             - name: GIT_ENABLE_REWRITE_RULE
               value: "false"
             - name: MUTATE_IMAGE_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/mutate-image:v0.8.0@sha256:f353f861aaee4dab5c1dd659295fb36af9c966ca47f7c7664d2ff1179fbc3f72
+              value: ghcr.io/shipwright-io/build/mutate-image:v0.9.0@sha256:77b8b659e1c4e6568f508e89124576a76c185ee8ddf77855e850ebf9941a7854
             - name: BUNDLE_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/bundle:v0.8.0@sha256:a6895fe36f81fc8314580c8c97a4a6aef0668ee9b6738787ab9f001627473dc3
+              value: ghcr.io/shipwright-io/build/bundle:v0.9.0@sha256:51ac2b3207b6e3bab6b5b21455df810abfe58adcac7f2c3a4dbb2bd95920fa09
             - name: WAITER_CONTAINER_IMAGE
-              value: ghcr.io/shipwright-io/build/waiter:v0.8.0@sha256:3dc5ded5f5cf52dc3536c36f9a6254518447ea9794a6c904e05123ee2d3251f1
+              value: ghcr.io/shipwright-io/build/waiter:v0.9.0@sha256:21d59cbaa3c8330759cd22c99132da1bd8fa2a076ee0ccf2675abaff696d92a5
           ports:
             - containerPort: 8383
               name: metrics-port
@@ -165,6 +165,49 @@ spec:
               port: metrics-port
             initialDelaySeconds: 5
             periodSeconds: 10
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: shipwright-build-aggregate-edit
+rules:
+  - apiGroups: ['shipwright.io']
+    resources: ['clusterbuildstrategies']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['shipwright.io']
+    resources: ['buildstrategies']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+  - apiGroups: ['shipwright.io']
+    resources: ['builds']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+  - apiGroups: ['shipwright.io']
+    resources: ['buildruns']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: shipwright-build-aggregate-view
+rules:
+  - apiGroups: ['shipwright.io']
+    resources: ['clusterbuildstrategies']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['shipwright.io']
+    resources: ['buildstrategies']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['shipwright.io']
+    resources: ['builds']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['shipwright.io']
+    resources: ['buildruns']
+    verbs: ['get', 'list', 'watch']
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -231,247 +274,8 @@ spec:
                   required:
                     - name
                   type: object
-                env:
-                  description: Env contains additional environment variables that should be passed to the build container
-                  items:
-                    description: EnvVar represents an environment variable present in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value. Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified API version.
-                                type: string
-                            required:
-                              - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes, optional for env vars'
-                                type: string
-                              divisor:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Specifies the output format of the exposed resources, defaults to "1"
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                output:
-                  description: Output refers to the location where the generated image would be pushed to. It will overwrite the output image in build spec
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations references the additional annotations to be applied on the image
-                      type: object
-                    credentials:
-                      description: Credentials references a Secret that contains credentials to access the image registry.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    image:
-                      description: Image is the reference of the image.
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels references the additional labels to be applied on the image
-                      type: object
-                  required:
-                    - image
-                  type: object
-                paramValues:
-                  description: Params is a list of key/value that could be used to set strategy parameters
-                  items:
-                    description: ParamValue is a key/value that populates a strategy parameter used in the execution of the strategy steps
-                    properties:
-                      configMapValue:
-                        description: The ConfigMap value of the parameter
-                        properties:
-                          format:
-                            description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
-                            type: string
-                          key:
-                            description: Key inside the object
-                            type: string
-                          name:
-                            description: Name of the object
-                            type: string
-                        required:
-                          - key
-                          - name
-                        type: object
-                      name:
-                        description: Name of the parameter
-                        type: string
-                      secretValue:
-                        description: The secret value of the parameter
-                        properties:
-                          format:
-                            description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
-                            type: string
-                          key:
-                            description: Key inside the object
-                            type: string
-                          name:
-                            description: Name of the object
-                            type: string
-                        required:
-                          - key
-                          - name
-                        type: object
-                      value:
-                        description: The value of the parameter
-                        type: string
-                      values:
-                        description: Values of an array parameter
-                        items:
-                          description: The value type contains the properties for a value, this allows for an easy extension in the future to support more kinds
-                          properties:
-                            configMapValue:
-                              description: The ConfigMap value of the parameter
-                              properties:
-                                format:
-                                  description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
-                                  type: string
-                                key:
-                                  description: Key inside the object
-                                  type: string
-                                name:
-                                  description: Name of the object
-                                  type: string
-                              required:
-                                - key
-                                - name
-                              type: object
-                            secretValue:
-                              description: The secret value of the parameter
-                              properties:
-                                format:
-                                  description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
-                                  type: string
-                                key:
-                                  description: Key inside the object
-                                  type: string
-                                name:
-                                  description: Name of the object
-                                  type: string
-                              required:
-                                - key
-                                - name
-                              type: object
-                            value:
-                              description: The value of the parameter
-                              type: string
-                          type: object
-                        type: array
-                    required:
-                      - name
-                    type: object
-                  type: array
-                serviceAccount:
-                  description: ServiceAccount refers to the kubernetes serviceaccount which is used for resource control. Default serviceaccount will be set if it is empty
-                  properties:
-                    generate:
-                      description: If generates a new ServiceAccount for the build
-                      type: boolean
-                    name:
-                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                      type: string
-                  type: object
-                sources:
-                  description: Sources slice of BuildSource, defining external build artifacts complementary to VCS (`.spec.source`) data.
-                  items:
-                    description: BuildSource remote artifact definition, also known as "sources". Simple "name" and "url" pairs, initially without "credentials" (authentication) support yet.
-                    properties:
-                      name:
-                        description: Name instance entry.
-                        type: string
-                      timeout:
-                        description: Timeout how long the BuildSource execution must take.
-                        type: string
-                      type:
-                        description: Type is the BuildSource qualifier, the type of the data-source.
-                        type: string
-                      url:
-                        description: URL remote artifact location.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                state:
-                  description: State is used for canceling a buildrun (and maybe more later on).
-                  type: string
-                timeout:
-                  description: Timeout defines the maximum run time of this BuildRun.
-                  format: duration
-                  type: string
-              required:
-                - buildRef
-              type: object
-            status:
-              description: BuildRunStatus defines the observed state of BuildRun
-              properties:
                 buildSpec:
-                  description: BuildSpec is the Build Spec of this BuildRun.
+                  description: BuildSpec refers to an embedded build specification
                   properties:
                     builder:
                       description: Builder refers to the image containing the build tools inside which the source code would be built.
@@ -511,7 +315,7 @@ spec:
                             description: Name of the environment variable. Must be a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                             type: string
                           valueFrom:
                             description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -697,6 +501,26 @@ spec:
                           - name
                         type: object
                       type: array
+                    retention:
+                      description: Contains information about retention params
+                      properties:
+                        failedLimit:
+                          description: FailedLimit defines the maximum number of failed buildruns that should exist.
+                          minimum: 1
+                          type: integer
+                        succeededLimit:
+                          description: SucceededLimit defines the maximum number of succeeded buildruns that should exist.
+                          minimum: 1
+                          type: integer
+                        ttlAfterFailed:
+                          description: TTLAfterFailed defines the maximum duration of time the failed buildrun should exist.
+                          format: duration
+                          type: string
+                        ttlAfterSucceeded:
+                          description: TTLAfterSucceeded defines the maximum duration of time the succeeded buildrun should exist.
+                          format: duration
+                          type: string
+                      type: object
                     source:
                       description: Source refers to the Git repository containing the source code to be built.
                       properties:
@@ -705,6 +529,582 @@ spec:
                           properties:
                             image:
                               description: Image reference, i.e. quay.io/org/image:tag
+                              type: string
+                            prune:
+                              description: "Prune specifies whether the image is suppose to be deleted. Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the image was successfully pulled from the registry). \n If not defined, it defaults to 'Never'."
+                              type: string
+                          required:
+                            - image
+                          type: object
+                        contextDir:
+                          description: ContextDir is a path to subfolder in the repo. Optional.
+                          type: string
+                        credentials:
+                          description: Credentials references a Secret that contains credentials to access the repository.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        revision:
+                          description: "Revision describes the Git revision (e.g., branch, tag, commit SHA, etc.) to fetch. \n If not defined, it will fallback to the repository's default branch."
+                          type: string
+                        url:
+                          description: URL describes the URL of the Git repository.
+                          type: string
+                      type: object
+                    sources:
+                      description: Sources slice of BuildSource, defining external build artifacts complementary to VCS (`.spec.source`) data.
+                      items:
+                        description: BuildSource remote artifact definition, also known as "sources". Simple "name" and "url" pairs, initially without "credentials" (authentication) support yet.
+                        properties:
+                          name:
+                            description: Name instance entry.
+                            type: string
+                          timeout:
+                            description: Timeout how long the BuildSource execution must take.
+                            type: string
+                          type:
+                            description: Type is the BuildSource qualifier, the type of the data-source.
+                            type: string
+                          url:
+                            description: URL remote artifact location.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    strategy:
+                      description: Strategy references the BuildStrategy to use to build the container image.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent
+                          type: string
+                        kind:
+                          description: BuildStrategyKind indicates the kind of the buildstrategy, namespaced or cluster scoped.
+                          type: string
+                        name:
+                          description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    timeout:
+                      description: Timeout defines the maximum amount of time the Build should take to execute.
+                      format: duration
+                      type: string
+                  required:
+                    - output
+                    - source
+                    - strategy
+                  type: object
+                env:
+                  description: Env contains additional environment variables that should be passed to the build container
+                  items:
+                    description: EnvVar represents an environment variable present in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes, optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                output:
+                  description: Output refers to the location where the generated image would be pushed to. It will overwrite the output image in build spec
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations references the additional annotations to be applied on the image
+                      type: object
+                    credentials:
+                      description: Credentials references a Secret that contains credentials to access the image registry.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    image:
+                      description: Image is the reference of the image.
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels references the additional labels to be applied on the image
+                      type: object
+                  required:
+                    - image
+                  type: object
+                paramValues:
+                  description: Params is a list of key/value that could be used to set strategy parameters
+                  items:
+                    description: ParamValue is a key/value that populates a strategy parameter used in the execution of the strategy steps
+                    properties:
+                      configMapValue:
+                        description: The ConfigMap value of the parameter
+                        properties:
+                          format:
+                            description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                            type: string
+                          key:
+                            description: Key inside the object
+                            type: string
+                          name:
+                            description: Name of the object
+                            type: string
+                        required:
+                          - key
+                          - name
+                        type: object
+                      name:
+                        description: Name of the parameter
+                        type: string
+                      secretValue:
+                        description: The secret value of the parameter
+                        properties:
+                          format:
+                            description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                            type: string
+                          key:
+                            description: Key inside the object
+                            type: string
+                          name:
+                            description: Name of the object
+                            type: string
+                        required:
+                          - key
+                          - name
+                        type: object
+                      value:
+                        description: The value of the parameter
+                        type: string
+                      values:
+                        description: Values of an array parameter
+                        items:
+                          description: The value type contains the properties for a value, this allows for an easy extension in the future to support more kinds
+                          properties:
+                            configMapValue:
+                              description: The ConfigMap value of the parameter
+                              properties:
+                                format:
+                                  description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                                  type: string
+                                key:
+                                  description: Key inside the object
+                                  type: string
+                                name:
+                                  description: Name of the object
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            secretValue:
+                              description: The secret value of the parameter
+                              properties:
+                                format:
+                                  description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                                  type: string
+                                key:
+                                  description: Key inside the object
+                                  type: string
+                                name:
+                                  description: Name of the object
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            value:
+                              description: The value of the parameter
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                      - name
+                    type: object
+                  type: array
+                retention:
+                  description: Contains information about retention params
+                  properties:
+                    ttlAfterFailed:
+                      description: TTLAfterFailed defines the maximum duration of time the failed buildrun should exist.
+                      format: duration
+                      type: string
+                    ttlAfterSucceeded:
+                      description: TTLAfterSucceeded defines the maximum duration of time the succeeded buildrun should exist.
+                      format: duration
+                      type: string
+                  type: object
+                serviceAccount:
+                  description: ServiceAccount refers to the kubernetes serviceaccount which is used for resource control. Default serviceaccount will be set if it is empty
+                  properties:
+                    generate:
+                      description: If generates a new ServiceAccount for the build
+                      type: boolean
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  type: object
+                sources:
+                  description: Sources slice of BuildSource, defining external build artifacts complementary to VCS (`.spec.source`) data.
+                  items:
+                    description: BuildSource remote artifact definition, also known as "sources". Simple "name" and "url" pairs, initially without "credentials" (authentication) support yet.
+                    properties:
+                      name:
+                        description: Name instance entry.
+                        type: string
+                      timeout:
+                        description: Timeout how long the BuildSource execution must take.
+                        type: string
+                      type:
+                        description: Type is the BuildSource qualifier, the type of the data-source.
+                        type: string
+                      url:
+                        description: URL remote artifact location.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                state:
+                  description: State is used for canceling a buildrun (and maybe more later on).
+                  type: string
+                timeout:
+                  description: Timeout defines the maximum run time of this BuildRun.
+                  format: duration
+                  type: string
+              type: object
+            status:
+              description: BuildRunStatus defines the observed state of BuildRun
+              properties:
+                buildSpec:
+                  description: BuildSpec is the Build Spec of this BuildRun.
+                  properties:
+                    builder:
+                      description: Builder refers to the image containing the build tools inside which the source code would be built.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations references the additional annotations to be applied on the image
+                          type: object
+                        credentials:
+                          description: Credentials references a Secret that contains credentials to access the image registry.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        image:
+                          description: Image is the reference of the image.
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels references the additional labels to be applied on the image
+                          type: object
+                      required:
+                        - image
+                      type: object
+                    dockerfile:
+                      description: Dockerfile is the path to the Dockerfile to be used for build strategies which bank on the Dockerfile for building an image.
+                      type: string
+                    env:
+                      description: Env contains additional environment variables that should be passed to the build container
+                      items:
+                        description: EnvVar represents an environment variable present in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes, optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    output:
+                      description: Output refers to the location where the built image would be pushed.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations references the additional annotations to be applied on the image
+                          type: object
+                        credentials:
+                          description: Credentials references a Secret that contains credentials to access the image registry.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        image:
+                          description: Image is the reference of the image.
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels references the additional labels to be applied on the image
+                          type: object
+                      required:
+                        - image
+                      type: object
+                    paramValues:
+                      description: Params is a list of key/value that could be used to set strategy parameters
+                      items:
+                        description: ParamValue is a key/value that populates a strategy parameter used in the execution of the strategy steps
+                        properties:
+                          configMapValue:
+                            description: The ConfigMap value of the parameter
+                            properties:
+                              format:
+                                description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                                type: string
+                              key:
+                                description: Key inside the object
+                                type: string
+                              name:
+                                description: Name of the object
+                                type: string
+                            required:
+                              - key
+                              - name
+                            type: object
+                          name:
+                            description: Name of the parameter
+                            type: string
+                          secretValue:
+                            description: The secret value of the parameter
+                            properties:
+                              format:
+                                description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                                type: string
+                              key:
+                                description: Key inside the object
+                                type: string
+                              name:
+                                description: Name of the object
+                                type: string
+                            required:
+                              - key
+                              - name
+                            type: object
+                          value:
+                            description: The value of the parameter
+                            type: string
+                          values:
+                            description: Values of an array parameter
+                            items:
+                              description: The value type contains the properties for a value, this allows for an easy extension in the future to support more kinds
+                              properties:
+                                configMapValue:
+                                  description: The ConfigMap value of the parameter
+                                  properties:
+                                    format:
+                                      description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                                      type: string
+                                    key:
+                                      description: Key inside the object
+                                      type: string
+                                    name:
+                                      description: Name of the object
+                                      type: string
+                                  required:
+                                    - key
+                                    - name
+                                  type: object
+                                secretValue:
+                                  description: The secret value of the parameter
+                                  properties:
+                                    format:
+                                      description: An optional format to add pre- or suffix to the object value. For example 'KEY=${SECRET_VALUE}' or 'KEY=${CONFIGMAP_VALUE}' depending on the context.
+                                      type: string
+                                    key:
+                                      description: Key inside the object
+                                      type: string
+                                    name:
+                                      description: Name of the object
+                                      type: string
+                                  required:
+                                    - key
+                                    - name
+                                  type: object
+                                value:
+                                  description: The value of the parameter
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    retention:
+                      description: Contains information about retention params
+                      properties:
+                        failedLimit:
+                          description: FailedLimit defines the maximum number of failed buildruns that should exist.
+                          minimum: 1
+                          type: integer
+                        succeededLimit:
+                          description: SucceededLimit defines the maximum number of succeeded buildruns that should exist.
+                          minimum: 1
+                          type: integer
+                        ttlAfterFailed:
+                          description: TTLAfterFailed defines the maximum duration of time the failed buildrun should exist.
+                          format: duration
+                          type: string
+                        ttlAfterSucceeded:
+                          description: TTLAfterSucceeded defines the maximum duration of time the succeeded buildrun should exist.
+                          format: duration
+                          type: string
+                      type: object
+                    source:
+                      description: Source refers to the Git repository containing the source code to be built.
+                      properties:
+                        bundleContainer:
+                          description: BundleContainer
+                          properties:
+                            image:
+                              description: Image reference, i.e. quay.io/org/image:tag
+                              type: string
+                            prune:
+                              description: "Prune specifies whether the image is suppose to be deleted. Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the image was successfully pulled from the registry). \n If not defined, it defaults to 'Never'."
                               type: string
                           required:
                             - image
@@ -797,6 +1197,9 @@ spec:
                         description: Type of condition
                         type: string
                     required:
+                      - lastTransitionTime
+                      - message
+                      - reason
                       - status
                       - type
                     type: object
@@ -876,6 +1279,8 @@ spec:
                   format: date-time
                   type: string
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -980,7 +1385,7 @@ spec:
                         description: Name of the environment variable. Must be a C_IDENTIFIER.
                         type: string
                       value:
-                        description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                        description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                         type: string
                       valueFrom:
                         description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -1166,6 +1571,26 @@ spec:
                       - name
                     type: object
                   type: array
+                retention:
+                  description: Contains information about retention params
+                  properties:
+                    failedLimit:
+                      description: FailedLimit defines the maximum number of failed buildruns that should exist.
+                      minimum: 1
+                      type: integer
+                    succeededLimit:
+                      description: SucceededLimit defines the maximum number of succeeded buildruns that should exist.
+                      minimum: 1
+                      type: integer
+                    ttlAfterFailed:
+                      description: TTLAfterFailed defines the maximum duration of time the failed buildrun should exist.
+                      format: duration
+                      type: string
+                    ttlAfterSucceeded:
+                      description: TTLAfterSucceeded defines the maximum duration of time the succeeded buildrun should exist.
+                      format: duration
+                      type: string
+                  type: object
                 source:
                   description: Source refers to the Git repository containing the source code to be built.
                   properties:
@@ -1174,6 +1599,9 @@ spec:
                       properties:
                         image:
                           description: Image reference, i.e. quay.io/org/image:tag
+                          type: string
+                        prune:
+                          description: "Prune specifies whether the image is suppose to be deleted. Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the image was successfully pulled from the registry). \n If not defined, it defaults to 'Never'."
                           type: string
                       required:
                         - image
@@ -1253,6 +1681,8 @@ spec:
                   description: The Register status of the Build
                   type: string
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -1306,12 +1736,12 @@ spec:
                     description: BuildStep defines a partial step that needs to run in container for building the image. If the build step declares a volumeMount, Shipwright will create an emptyDir volume mount for the named volume. Build steps which share the same named volume in the volumeMount will share the same underlying emptyDir volume. This behavior is deprecated, and will be removed when full volume support is added to build strategies as specified in SHIP-0022.
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         items:
                           type: string
                         type: array
                       command:
-                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         items:
                           type: string
                         type: array
@@ -1324,7 +1754,7 @@ spec:
                               description: Name of the environment variable. Must be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -1438,7 +1868,7 @@ spec:
                             description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: Exec specifies the action to take.
                                 properties:
                                   command:
                                     description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -1484,7 +1914,7 @@ spec:
                                   - port
                                 type: object
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1500,10 +1930,10 @@ spec:
                                 type: object
                             type: object
                           preStop:
-                            description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: Exec specifies the action to take.
                                 properties:
                                   command:
                                     description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -1549,7 +1979,7 @@ spec:
                                   - port
                                 type: object
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1569,7 +1999,7 @@ spec:
                         description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             properties:
                               command:
                                 description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -1581,6 +2011,19 @@ spec:
                             description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             properties:
@@ -1631,7 +2074,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1646,7 +2089,7 @@ spec:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
@@ -1692,7 +2135,7 @@ spec:
                         description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             properties:
                               command:
                                 description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -1704,6 +2147,19 @@ spec:
                             description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             properties:
@@ -1754,7 +2210,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1769,7 +2225,7 @@ spec:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
@@ -1800,13 +2256,13 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -1822,27 +2278,27 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                            description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                            description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false.
+                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
                             description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies to the container.
@@ -1858,7 +2314,7 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
                                 description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
@@ -1870,7 +2326,7 @@ spec:
                               - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
                                 description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
@@ -1878,6 +2334,9 @@ spec:
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                 type: string
+                              hostProcess:
+                                description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
                               runAsUserName:
                                 description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
@@ -1887,7 +2346,7 @@ spec:
                         description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             properties:
                               command:
                                 description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -1899,6 +2358,19 @@ spec:
                             description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             properties:
@@ -1949,7 +2421,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1964,7 +2436,7 @@ spec:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
@@ -2121,12 +2593,12 @@ spec:
                     description: BuildStep defines a partial step that needs to run in container for building the image. If the build step declares a volumeMount, Shipwright will create an emptyDir volume mount for the named volume. Build steps which share the same named volume in the volumeMount will share the same underlying emptyDir volume. This behavior is deprecated, and will be removed when full volume support is added to build strategies as specified in SHIP-0022.
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         items:
                           type: string
                         type: array
                       command:
-                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         items:
                           type: string
                         type: array
@@ -2139,7 +2611,7 @@ spec:
                               description: Name of the environment variable. Must be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value. Cannot be used if value is not empty.
@@ -2253,7 +2725,7 @@ spec:
                             description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: Exec specifies the action to take.
                                 properties:
                                   command:
                                     description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -2299,7 +2771,7 @@ spec:
                                   - port
                                 type: object
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2315,10 +2787,10 @@ spec:
                                 type: object
                             type: object
                           preStop:
-                            description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: Exec specifies the action to take.
                                 properties:
                                   command:
                                     description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -2364,7 +2836,7 @@ spec:
                                   - port
                                 type: object
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2384,7 +2856,7 @@ spec:
                         description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             properties:
                               command:
                                 description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -2396,6 +2868,19 @@ spec:
                             description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             properties:
@@ -2446,7 +2931,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2461,7 +2946,7 @@ spec:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
@@ -2507,7 +2992,7 @@ spec:
                         description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             properties:
                               command:
                                 description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -2519,6 +3004,19 @@ spec:
                             description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             properties:
@@ -2569,7 +3067,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2584,7 +3082,7 @@ spec:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
@@ -2615,13 +3113,13 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -2637,27 +3135,27 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                            description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                            description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false.
+                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
                             description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies to the container.
@@ -2673,7 +3171,7 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
                                 description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
@@ -2685,7 +3183,7 @@ spec:
                               - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
                                 description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
@@ -2693,6 +3191,9 @@ spec:
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                 type: string
+                              hostProcess:
+                                description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
                               runAsUserName:
                                 description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
@@ -2702,7 +3203,7 @@ spec:
                         description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             properties:
                               command:
                                 description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
@@ -2714,6 +3215,19 @@ spec:
                             description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             properties:
@@ -2764,7 +3278,7 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2779,7 +3293,7 @@ spec:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/shipwright-io/operator/operator
-  newTag: 0.8.1-snapshot
+  newTag: 0.9.0-rc.0

--- a/config/manifests/bases/shipwright-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/shipwright-operator.clusterserviceversion.yaml
@@ -49,8 +49,7 @@ spec:
 
     The operator will deploy Shipwright Builds in the provided `targetNamespace`.
     When `.spec.targetNamespace` is not set, the namespace will default to `shipwright-build`.
-
-    _Note: this namespace needs to be created before the actual deployment takes place._
+    Refer to the [ShipwrightBuild documentation](https://github.com/shipwright-io/operator/blob/main/docs/shipwrightbuild.md) for more information about this custom resource.
   displayName: Shipwright Operator
   icon:
   - base64data: |

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,5 @@ resources:
 - shipwright_build_controller_ns_role_binding.yaml
 - shipwright_build_controller_role.yaml
 - shipwright_build_controller_role_binding.yaml
+- shipwright_build_aggregate_role.yaml
+- shipwright_build_aggregate_role_binding.yaml

--- a/config/rbac/shipwright_build_aggregate_role.yaml
+++ b/config/rbac/shipwright_build_aggregate_role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: build-aggregate
+rules:
+  - apiGroups: ['shipwright.io']
+    resources: ['clusterbuildstrategies']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['shipwright.io']
+    resources: ['buildstrategies']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+  - apiGroups: ['shipwright.io']
+    resources: ['builds']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+  - apiGroups: ['shipwright.io']
+    resources: ['buildruns']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']

--- a/config/rbac/shipwright_build_aggregate_role_binding.yaml
+++ b/config/rbac/shipwright_build_aggregate_role_binding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-aggregate
+roleRef:
+  kind: ClusterRole
+  name: build-aggregate
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: system

--- a/docs/shipwrightbuild.md
+++ b/docs/shipwrightbuild.md
@@ -1,0 +1,13 @@
+# ShipwrightBuild Custom Resource
+
+When the Shipwright Operator is installed with the Operator Lifecycle Manager, the
+`ShipwrightBuild` [custom resource definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) is added to your cluster.
+This custom resource is used to install and configure Shipwright Builds on your cluster.
+The current operator will install version `0.9.0` of Builds.
+
+## ShipwrightBuild Reference
+
+| Field | Description |
+| ----- | ----------- |
+| spec.targetNamespace | The target namespace where Shipwright Build will be deployed. If omitted, this will default to `shipwright-build` |
+| status.conditions | Conditions which report the status of Shipwright Build. Current reported conditions:<br><br>- `Ready` |


### PR DESCRIPTION
# Changes

- Deploy Shipwright Build v0.9.0
- Update version to release candidate.
- Describe the fields in the ShipwrightBuild CRD.
- Indicate which version of Shipwright Builds is installed.
- Add installation instructions to the README.
- Remove instruction that the target namespace needs to be created
  first.

Fixes #51 

/kind feature
/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Deploy ShipwrightBuild v0.9.0 and improve installation documentation.
```

