### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+    time: "06:00"
+  labels:
+  - kind/dependency-change
+  - release-note-none
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: k8s.io/*
+  - dependency-name: sigs.k8s.io/*


### PR DESCRIPTION
# Changes

Enabling dependabot alerts based on decision in the https://github.com/shipwright-io/community/issues/78.

Settings are explained in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

Fixes #72

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```