### PR TITLE
Add permission to manage aggregated clusterroles

### DIFF
--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -517,6 +517,26 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resourceNames:
+          - shipwright-build-aggregate-edit
+          resources:
+          - clusterroles
+          verbs:
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - shipwright-build-aggregate-view
+          resources:
+          - clusterroles
+          verbs:
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
           - shipwright-build-controller
           resources:
           - clusterroles

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,6 +148,26 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
+  - shipwright-build-aggregate-edit
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - shipwright-build-aggregate-view
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
   - shipwright-build-controller
   resources:
   - clusterroles

--- a/controllers/shipwrightbuild_rbac.go
+++ b/controllers/shipwrightbuild_rbac.go
@@ -13,6 +13,8 @@ package controllers
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,resourceNames=builds.shipwright.io;buildruns.shipwright.io;buildstrategies.shipwright.io;clusterbuildstrategies.shipwright.io,verbs=update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=shipwright-build-aggregate-edit,verbs=update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=shipwright-build-aggregate-view,verbs=update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=shipwright-build-controller,verbs=update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=shipwright-build-controller,verbs=update;patch;delete


### PR DESCRIPTION
# Changes

Fixing the missing permissions to delete the aggregated cluster roles when removing a `ShipwrightBuild` object.

Still familiarizing on how to develop with this repo, so cannot provide e2e test case as described in #71, but we need the fix in v0.10.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Adding missing permissions for the operator to cleanup the aggregated cluster roles that Shipwright v0.9 introduced.
```