### PR TITLE
Fix signing of released image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.18.x
-    - uses: sigstore/cosign-installer@v1.2.0
+    - uses: sigstore/cosign-installer@v2.3.0
     - name: Build Release Images
       env:
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
         # OIDC.
         COSIGN_EXPERIMENTAL: "true"
       run: |
-        grep -o "ghcr.io[^\"]*" "${GITHUB_WORKSPACE}/bundle/manifests/shipwright-operator.clusterserviceversion.yaml" | xargs cosign sign \
+        grep -o "ghcr.io[^\"]*" "${GITHUB_WORKSPACE}/_output/olm/bundle/manifests/shipwright-operator.clusterserviceversion.yaml" | uniq | xargs -n 1 cosign sign \
             -a sha=${{ github.sha }} \
             -a run_id=${{ github.run_id }} \
             -a run_attempt=${{ github.run_attempt }}


### PR DESCRIPTION
# Changes

In 0b91c10b, the CSV stored in git was altered to include the `ko://`
image reference. The real image reference is generated at build time,
and its "resolved" CSV is stored in an ignored directory. This
unfortunately broke the release GitHub action, which greps the in-tree
CSV fo images to sign.

This updates the release action to look at the "resolved" CSV in the
`_output/olm` directory when searching for images to sign. This also
updates cosign-installer to v2.3.0.

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fix bug that caused the signing of the operator image to fail.
```
