### PR TITLE
Update go to 1.20 and ko to v0.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
         cache: true
         check-latest: true
     - name: Build
@@ -33,7 +33,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
         cache: true
         check-latest: true
     - name: Verify fmt
@@ -62,7 +62,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
         cache: true
         check-latest: true
     - name: Install kubectl

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ KO ?= $(LOCALBIN)/ko
 
 ## Tool Versions
 
-KO_VERSION ?= v0.11.2
+KO_VERSION ?= v0.15.0
 
 .PHONY: ko
 ko: $(KO) ## Download ko locally if necessary

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 * Ensure you have access to a Kubernetes cluster via `kubectl` with cluster admin permissions.
-* Install Go version 1.18 or higher.
+* Install [Go](https://go.dev/doc/install) version 1.20 or higher.
 
 ## Building locally
 
@@ -28,7 +28,7 @@ The following make options can be set:
 * `VERSION` - defaults to the current version of Shipwright.
   This must be a valid [semantic version](https://semver.org/), and will be used as the tag for the resulting image.
 
-Refer to the [ko documentation](https://github.com/google/ko#local-publishing-options) for more information.
+Refer to the [ko documentation](https://ko.build/) for more information.
 
 ## Deploy to Kubernetes
 

--- a/docs/development/olm-development.md
+++ b/docs/development/olm-development.md
@@ -9,7 +9,7 @@ Additional steps need to be taken to ensure the operator can be deployed with OL
 ## Prerequisites
 
 * Ensure you have access to a Kubernetes cluster via `kubectl` with cluster admin permissions.
-* Install Go version 1.17 or higher.
+* Install [Go](https://go.dev/doc/install) version 1.20 or higher.
 * Install OLM on your cluster. This can be done using the `make install-olm` command.
 * Ability to push to a container registry that is accessible inside your Kubernetes cluster.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipwright-io/operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d

--- a/hack/install-ko.sh
+++ b/hack/install-ko.sh
@@ -8,7 +8,7 @@
 set -e
 
 DEST="${1:-bin/ko}"
-KO_VERSION="${KO_VERSION:-0.11.2}"
+KO_VERSION="${KO_VERSION:-0.15.0}"
 
 OS="${OS:-linux}"
 ARCH="${ARCH:-amd64}"


### PR DESCRIPTION
# Changes

Update build to use golang 1.20.x, and ko to v0.15.0 (latest release).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
