### PR TITLE
Add Developer Guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,54 @@
+# Developer Guide
+
+Want to add a new feature (or fix bugs) in the operator? This document will help you understand how
+to build, test, and deploy the operator.
+
+## Prerequisites
+
+Before you begin, ensure you have have a development environment well suited for Go and Kubernetes
+development:
+
+- Install [Go](https://go.dev/doc/install) version 1.20 or higher. We recommend using an
+  interactive development environment (IDE) that supports go, such as
+  [GoLand](https://www.jetbrains.com/go/) or [VSCode](https://code.visualstudio.com/).
+- Install a container engine that can build and run container images. We recommend
+  [docker](https://docs.docker.com/get-docker/) or [podman](https://podman.io/).
+- Obtain access to a Kubernetes cluster that you have administrative permissions on. This can be a
+  "micro" distribution such as [kind](https://kind.sigs.k8s.io/), or a fully managed cluster like
+  [GKE](https://cloud.google.com/kubernetes-engine). We recommend `kind` for local development.
+
+
+## Operator Foundations
+
+This project builds a Kubernetes [operator](https://operatorframework.io/what/) for Shipwright
+projects, such as [build](https://github.com/shipwright-io/build). It is scaffolded with
+[Operator SDK](https://sdk.operatorframework.io/) and its related Kubernetes development framework,
+[kubebuilder](https://book.kubebuilder.io/). Those who are new to Kubernetes concepts like
+controllers and custom resources are encouraged to try  the
+[Operator SDK go tutorial](https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/)
+first.
+
+Operator SDK and kubebuilder are strongly opinionated when it comes to project structure.
+Contributors should use `operator-sdk` [commands](https://sdk.operatorframework.io/docs/cli/) or
+`kubebuilder` [commands](https://github.com/kubernetes-sigs/kubebuilder) when adding new custom
+resources or controllers. Code within the `pkg/` directory is generally safe from these
+generators and should be reserved for core reconciliation logic ("business logic").
+
+This project also generates an
+[operator bundle](https://sdk.operatorframework.io/docs/olm-integration/tutorial-bundle/), which is
+used to deploy the operator on a cluster with
+[Operator Lifecycle Manager](https://olm.operatorframework.io/) (OLM). Refer to the
+[OLM core tasks](https://olm.operatorframework.io/docs/tasks/) for the steps needed to deploy an
+operator with OLM.
+
+
+## Development Flows
+
+Most features and bug fixes only require the operator and its related custom resource definitions
+to be deployed on Kubernetes. The [local development guide](/docs/development/local-development.md)
+describes how to build, deploy, and test your changes against a Kubernetes cluster.
+
+Changes that modify the `bundle` directory, however, may require the operator to be packaged and
+deployed with Operator Lifecycle Manager. Refer to the
+[OLM development guide](/docs/development/olm-development.md) for instructions on how to build,
+deploy, and test the operator with OLM.

--- a/README.md
+++ b/README.md
@@ -54,5 +54,9 @@ For more information about the function of these images, please consider the Shi
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to build, test, and submit
-contributions to the operator.
+Please review the overall project
+[Contributing Guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md) before
+submitting bug reports, feature requests, or code.
+
+Want to start hacking on the operator? Refer to the [Development Guilde](DEVELOPMENT.md) to learn
+how to build, test, and deploy the operator.


### PR DESCRIPTION
# Changes

This adds a developer guide that serves as an entrypoint for new code contributors. The operator project has existing documentation for local and OLM development, however it is buried in a nested directory that is not easy to find. Those documents also miss critical foundational knowledge, such as dev prerequisites and an understanding of OLM.

This PR also fixes the broken link to the contributor guidelines.

/kind documentation

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
