### PR TITLE
Update operator-sdk to v1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,17 @@ KO_OPTS ?= -B -t ${TAG} --sbom=${SBOM}
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
+# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+
+# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
+# You can enable this value if you would like to use SHA Based Digests
+# To enable set flag to true
+USE_IMAGE_DIGESTS ?= false
+ifeq ($(USE_IMAGE_DIGESTS), true)
+    BUNDLE_GEN_FLAGS += --use-image-digests
+endif
+
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -221,7 +232,7 @@ endef
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ko ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests --interactive=false -q
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: verify-bundle

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=shipwright-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.17.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/shipwright-operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/shipwright-operator-metrics-service_v1_service.yaml
@@ -13,5 +13,6 @@ spec:
     targetPort: https
   selector:
     app: shipwright-operator
+    control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     certified: "false"
     containerImage: ko://github.com/shipwright-io/operator
     description: Shipwright is a framework for building container images on Kubernetes.
-    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/shipwright-io/operator
     support: The Shipwright Contributors
@@ -759,13 +759,15 @@ spec:
           selector:
             matchLabels:
               app: shipwright-operator
+              control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               annotations:
-                kubectl.kubernetes.io/default-container: operator
+                kubectl.kubernetes.io/default-container: manager
               labels:
                 app: shipwright-operator
+                control-plane: controller-manager
             spec:
               containers:
               - args:
@@ -800,7 +802,7 @@ spec:
                     port: 8081
                   initialDelaySeconds: 15
                   periodSeconds: 20
-                name: operator
+                name: manager
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: shipwright-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.17.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,7 +27,7 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      - name: operator
+      - name: manager
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,17 +12,20 @@ metadata:
   namespace: system
   labels:
     app: shipwright-operator
+    control-plane: controller-manager
 spec:
   selector:
     matchLabels:
       app: shipwright-operator
+      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: operator
+        kubectl.kubernetes.io/default-container: manager
       labels:
         app: shipwright-operator
+        control-plane: controller-manager
     spec:
       securityContext:
         runAsNonRoot: true
@@ -33,7 +36,7 @@ spec:
         - name: USE_MANAGED_WEBHOOK_CERTS
           value: "true"
         image: ko://github.com/shipwright-io/operator
-        name: operator
+        name: manager
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app: shipwright-operator
+    control-plane: controller-manager
   name: operator-metrics-monitor
   namespace: system
 spec:
@@ -18,3 +19,4 @@ spec:
   selector:
     matchLabels:
       app: shipwright-operator
+      control-plane: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -13,3 +13,4 @@ spec:
     targetPort: https
   selector:
     app: shipwright-operator
+    control-plane: controller-manager

--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -9,7 +9,7 @@
 set -e
 
 DEST="${1:-bin/operator-sdk}"
-SDK_VERSION="${SDK_VERSION:-1.17.0}"
+SDK_VERSION="${SDK_VERSION:-1.18.0}"
 
 OS="${OS:-linux}"
 ARCH="${ARCH:-amd64}"


### PR DESCRIPTION
# Changes

Upgrade operator-sdk to v1.18, bringing in the following enhancements:

- Ability to use image digests in the released operator bundle (v1.18.0)
- Fix deployment to align with operator-sdk requirements.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add `control-plane` label to operator deployment so it supports bundling with operator-sdk v1.18
```

