### PR TITLE
Skip EnvTest Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,12 @@ verify-fmt: fmt ## Verify formatting and ensure git status is clean
 vet: ## Run go vet against code.
 	go vet ./...
 
+SKIP_ENVTEST ?= false
+
 BINDATA = $(shell pwd)/kodata
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KO_DATA_PATH=${BINDATA} KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -p 1 -failfast -test.v -test.failfast
+test: manifests generate fmt vet envtest ## Run tests. To bypass longer-running reconcile tests with EnvTest, set SKIP_ENVTEST=true.
+	KO_DATA_PATH=${BINDATA} KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" SKIP_ENVTEST=${SKIP_ENVTEST} go test ./... -coverprofile cover.out -failfast -test.v -test.failfast
 
 ##@ Build
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -6,7 +6,9 @@ package controllers
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -42,6 +44,11 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	skip := os.Getenv("SKIP_ENVTEST")
+	shouldSkip, _ := strconv.ParseBool(skip)
+	if shouldSkip {
+		t.Skip("bypassing Ginkgo-driven tests")
+	}
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(restTimeout)
 	SetDefaultEventuallyPollingInterval(restRetry)


### PR DESCRIPTION
# Changes

Add option to skip the reconcile tests that utilize EnvTest. These tests have a noticeable amout of setup time, and failure cases can take over 30 seconds each to be identified due to timeouts. The skip option will execute test cases that do not require EnvTest, which are more likely to be standard golang unit tests that execute quickly.

This also drops the `-p 1` parameter passed to `go test`, which allows go to execute tests in parallel.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
