### PR TITLE
Operator should not delete CRDs

### DIFF
--- a/controllers/default_test.go
+++ b/controllers/default_test.go
@@ -232,8 +232,8 @@ var _ = g.Describe("Reconcile default ShipwrightBuild installation", func() {
 			test.EventuallyRemoved(ctx, k8sClient, expectedDeployment)
 		})
 
-		// TODO: Do not delete the CRDs! This is something only a cluster admin should do.
-		g.It("deletes the custom resource definitions for the Shipwright build APIs", func(ctx g.SpecContext) {
+		// Deteling the build instance should not delete CRDS
+		g.It("should not delete the custom resource definitions for the Shipwright build APIs", func(ctx g.SpecContext) {
 			test.CRDEventuallyExists(ctx, k8sClient, "builds.shipwright.io")
 			test.CRDEventuallyExists(ctx, k8sClient, "buildruns.shipwright.io")
 			test.CRDEventuallyExists(ctx, k8sClient, "buildstrategies.shipwright.io")
@@ -244,10 +244,10 @@ var _ = g.Describe("Reconcile default ShipwrightBuild installation", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// Verify - check the behavior
-			test.CRDEventuallyRemoved(ctx, k8sClient, "builds.shipwright.io")
-			test.CRDEventuallyRemoved(ctx, k8sClient, "buildruns.shipwright.io")
-			test.CRDEventuallyRemoved(ctx, k8sClient, "buildstrategies.shipwright.io")
-			test.CRDEventuallyRemoved(ctx, k8sClient, "clusterbuildstrategies.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "builds.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "buildruns.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "buildstrategies.shipwright.io")
+			test.CRDEventuallyExists(ctx, k8sClient, "clusterbuildstrategies.shipwright.io")
 		})
 	})
 

--- a/controllers/shipwrightbuild_controller.go
+++ b/controllers/shipwrightbuild_controller.go
@@ -197,7 +197,7 @@ func (r *ShipwrightBuildReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		logger.Info("Deleting manifests...")
-		if err := manifest.Delete(); err != nil {
+		if err := manifest.Filter(manifestival.NoCRDs).Delete(); err != nil {
 			logger.Error(err, "deleting manifest's resources")
 			return RequeueWithError(err)
 		}


### PR DESCRIPTION
# Changes

- Filter Crds before deleting resources because operator should not delete Crds when shipwright instance is deleted

Fixes #173 

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Shipwright's Build CRDs are no longer deleted when the `ShipwrightBuild` object is deleted.
```
