### PR TITLE
[release-v0.12] SHIP-0038: Run CI on Release Branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: ci/github
 
 on: 
   pull_request:
-    branches: [ main ]
+    branches: 
+      - main
+      - "release-v*" # release branches
   push:
-    branches: [ main ]
+    branches: 
+      - main
+      - "release-v*" # release branches
 
 permissions:
   contents: read


### PR DESCRIPTION
# Changes

Update our CI-oriented GitHub actions to run when commits merge in a `release-v*` branch, or a pull request is opened against a `release-v*` branch. With this change, future release branches will automatically have CI checks enabled. This commit should be backported to enable CI in a prior release branch.

This implements a portion of SHIP-0038.

https://github.com/shipwright-io/community/issues/85

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```