### PR TITLE
removing description fields preventing the manifest from being too long

### DIFF
--- a/controllers/shipwrightbuild_controller.go
+++ b/controllers/shipwrightbuild_controller.go
@@ -171,6 +171,7 @@ func (r *ShipwrightBuildReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.ShipwrightImagePrefix))
 
 	transformerfncs := []manifestival.Transformer{}
+	transformerfncs = append(transformerfncs, common.TruncateDescription())
 	if common.IsOpenShiftPlatform() {
 		transformerfncs = append(transformerfncs, manifestival.InjectNamespace(targetNamespace))
 		transformerfncs = append(transformerfncs, common.DeploymentImages(images))


### PR DESCRIPTION
Adding a transformer in the manifestival to remove the description fields. It attempts to fix #184 
