### PR TITLE
Truncate CRD Description Fields to 50 Characters

### DIFF
--- a/controllers/shipwrightbuild_controller.go
+++ b/controllers/shipwrightbuild_controller.go
@@ -171,6 +171,7 @@ func (r *ShipwrightBuildReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.ShipwrightImagePrefix))
 
 	transformerfncs := []manifestival.Transformer{}
+	transformerfncs = append(transformerfncs, common.TruncateCRDFieldTransformer("description", 50))
 	if common.IsOpenShiftPlatform() {
 		transformerfncs = append(transformerfncs, manifestival.InjectNamespace(targetNamespace))
 		transformerfncs = append(transformerfncs, common.DeploymentImages(images))

--- a/pkg/common/testdata/test-truncate-crd-field.yaml
+++ b/pkg/common/testdata/test-truncate-crd-field.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test.crd.com
+spec:
+  group: crd.com
+  versions:
+  - name: v1
+    served: true
+    description: This is a long string that should be truncated
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          description: This is a long string that should be truncated
+          spec:
+            properties:
+              field1:
+                type: string
+                description: This is a long string that should be truncated
+  scope: Namespaced
+  names:
+    plural: tests
+    singular: test
+    kind: Test
+    shortNames:
+    - tst


### PR DESCRIPTION
# Changes

Adding a TruncateField transformer and using it to truncate CRD description fields from the `kodata/release.yaml` manifest. The CRDs for Shipwright Build objects are very large, resulting in a validation error from Kubernetes when we try to create the CRDs with Manifestival.

Partially addresses #184 

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Tructate descriptions in Shipwright custom resource definitions to 50 characters.
```
