### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
         cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
         go-version: 1.21.x
         cache: true
         check-latest: true
-    - uses: sigstore/cosign-installer@v2
+    - uses: sigstore/cosign-installer@v3
     - name: Build Release Images
       env:
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Changes

- Update ci to use checkout@v4, setup-go@v5
- Update cosign-installer to v3

Note - updating cosign is needed so we use the latest version. Older versions can't talk to Fulcio - see [sigstore announcement](https://blog.sigstore.dev/tuf-root-update/)

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
