### PR TITLE
fix: Add --yes to cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0  # Fetch all history, needed for release note generation.
     # Install tools
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
         cache: true
@@ -54,7 +54,8 @@ jobs:
         grep -o "ghcr.io[^\"]*" "${GITHUB_WORKSPACE}/_output/olm/bundle/manifests/shipwright-operator.clusterserviceversion.yaml" | uniq | xargs -n 1 cosign sign \
             -a sha=${{ github.sha }} \
             -a run_id=${{ github.run_id }} \
-            -a run_attempt=${{ github.run_attempt }}
+            -a run_attempt=${{ github.run_attempt }} \
+            --yes
     - name: Build Release Changelog
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

# Changes

Add --yes to cosign command. Newer cosign by default has an interactive prompt. Pass the `--yes` option to acknowledge the prompt ahead of time.

/kind bug

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

