### PR TITLE
doc: Procedure to Publish Operator on OperatorHub

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -4,6 +4,10 @@ This document outlines the steps required to release the operator. This document
 have achieved the "Approver"/"Maintainer" status, and have permission to manually trigger GitHub
 Actions on this repo.
 
+To release operator updates to the [k8s community operators](https://github.com/k8s-operatorhub/community-operators),
+you must be listed as an approver in our [operator CI configuration](https://github.com/k8s-operatorhub/community-operators/blob/main/operators/shipwright-operator/ci.yaml)
+or request approval from a listed GitHub user.
+
 ## Release Candidates (`X.Y.0-rcN`)
 
 ### Step 0: Set Up the Release Branch
@@ -78,3 +82,49 @@ Work with the community to get these pull requests merged.
 Repeat the process in [Step 1](#step-1-create-a-release-candidate) and
 [Step 2](#step-2-publish-draft-release) above to create the release. For an official release, the
 version should adhere to the `X.Y.Z` format (not extra dashes).
+
+### Step 3 (if needed): Set up your machine to run the OperatorHub release script
+
+The OperatorHub release script requires the following:
+
+1. Fork the [k8s community-operators](https://github.com/k8s-operatorhub/community-operators)
+   repository.
+2. Clone your fork with the `origin` remote name. Be sure to set your name and email in your local
+   `git` configuration.
+3. Add the community operators repository as the `upstream` remote:
+
+   ```sh
+   $ git remote add upstream https://github.com/k8s-operatorhub/community-operators.git
+   ```
+
+4. Install the [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
+   tool locally.
+
+### Step 4: Update the Operator on OperatorHub.io
+
+[OperatorHub.io](https://operatorhub.io) publishes a catalog of operators sourced from git. To add
+a new operator version, we must submit a pull request to the appropriate git repository.
+
+Run the script `./hack/release-operatorhub.sh` to create a new release branch in your fork. The
+script defaults to submitting pull requests to the k8s-operatorhub/community-operators catalog, but
+other catalogs with the same format are supported.
+
+The script accepts the following environment variables:
+
+- `OPERATORHUB_DIR`: directory where the operator catalog repository was cloned. 
+- `VERSION`: version of the operator to submit for update. Do not include the leading `v` in the
+   version name.
+- `HUB_REPO`: Regular expression to match for the operator catalog. Defaults to
+  `k8s-operatorhub\/community-operators` - be sure to escape special characters when overriding
+  this value.
+
+Once the script completes and pushes the branch to your fork, open a pull request against the
+[community operators](https://github.com/k8s-operatorhub/community-operators) repository.
+
+### Step 5 (optional): Update other operator catalogs
+
+OperatorHub.io is not the only catalog that can be used to publish operators on Kubernetes
+clusters. Community members can use the `release-operatorhub.sh` script to update any other catalog
+that uses the OperatorHub file structure by providing appropriate environment variable overrides.
+
+Maintainers are not required to submit updates to other operator catalogs.

--- a/hack/release-operatorhub.sh
+++ b/hack/release-operatorhub.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# This script generates a pull request to add the release to operatorhub.io
+# Prerequisites:
+# - The user has cloned and forked the operator catalog repository
+# - The machine running this script has crane installed: https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
+
+# Environment variables to tune the script's behavior
+# - OPERATORHUB_DIR: The local path to the operator catalog repository.
+# - VERSION: The version of the operator to release.
+# - HUB_REPO: A regular expression to match the GitHub org/repository of the catalog. Note that this
+#   is a regular expression, so special characters need to be escaped.
+
+OPERATORHUB_DIR=${OPERATORHUB_DIR:-$HOME/go/src/github.com/k8s-operatorhub/community-operators}
+VERSION=${VERSION:-latest}
+HUB_REPO=${HUB_REPO:-"k8s-operatorhub\/community-operators"}
+# Regular expression match [https://github.com/|git@github.com:]
+hubRegEx="(https:\/\/github\.com\/|git@github\.com:)${HUB_REPO}"
+
+echo "Preparing to release Shipwright Operator ${VERSION} to Operator catalog github.com/${HUB_REPO}"
+
+if [[ ! -d "$OPERATORHUB_DIR" ]]; then
+  echo "Please clone the operator catalog repository repository to $OPERATORHUB_DIR"
+  exit 1
+fi
+
+pushd "$OPERATORHUB_DIR"
+
+originURL=$(git remote get-url origin)
+if [[ "$originURL" =~ ${hubRegEx} ]]; then
+  echo "Please set the origin remote to your fork of the operator catalog repository"
+  exit 1
+fi
+
+upstreamURL=$(git remote get-url upstream)
+if [[ ! "$upstreamURL" =~ ${hubRegEx} ]]; then
+  echo "Please set the upstream remote ${upstreamURL} to the operator catalog repository"
+  exit 1
+fi
+
+git fetch
+git switch main
+git pull upstream main
+git checkout -b "shipwright-${VERSION}"
+
+mkdir -p "operators/shipwright-operator/${VERSION}"
+pushd "operators/shipwright-operator/${VERSION}"
+
+crane export "ghcr.io/shipwright-io/operator/operator-bundle:v${VERSION}" - | tar -xv
+
+popd
+
+# Commit and push changes to our GitHub fork
+git add "operators/shipwright-operator/${VERSION}"
+git commit -m "Update Shipwright Operator to ${VERSION}" -s
+git push --set-upstream origin "shipwright-${VERSION}"
+
+popd


### PR DESCRIPTION
# Changes

Add a procedure and script to publish an operator release to the upstream k8s community operators OperatorHub. The script requires the user to fork the upstream k8s operators repsository and afterwards submit a pull request by hand.

In the future this procedure/script can be added to our release automation so when an operator release is published, we initiate the process to update the upstream OperatorHub catalog.

Fixes #132 

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
