### PR TITLE
Use Go `1.22` in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: ci/github
 
-on: 
+on:
   pull_request:
-    branches: 
+    branches:
       - main
       - "release-v*" # release branches
   push:
-    branches: 
+    branches:
       - main
       - "release-v*" # release branches
 
@@ -22,7 +22,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: true
         check-latest: true
     - name: Build
@@ -37,7 +37,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: true
         check-latest: true
     - name: Verify fmt
@@ -69,7 +69,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: true
         check-latest: true
     - name: Install kubectl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: true
         check-latest: true
     - uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
# Changes

Use latest Go version `1.22` for any Go related GitHub Action.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
