### PR TITLE
fix: Set TektonConfig Pruner

### DIFF
--- a/pkg/tekton/tekton.go
+++ b/pkg/tekton/tekton.go
@@ -102,6 +102,9 @@ func IsTektonConfigPresent(ctx context.Context, client tektonoperatorclientv1alp
 // CreateTektonConfigWithProfileAndTargetNamespace creates a TektonConfig object with the given
 // profile and target namespace for Tekton components.
 func CreateTektonConfigWithProfileAndTargetNamespace(ctx context.Context, client tektonoperatorclientv1alpha1.OperatorV1alpha1Interface, profile string, targetNamepsace string) (*tektonoperatorv1alpha1.TektonConfig, error) {
+	// If creating a TektonConfig, enable the pruner with default keep of 100
+	// This matches the Tekton operator default
+	keep := uint(100)
 	tektonConfig := &tektonoperatorv1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "config",
@@ -110,6 +113,10 @@ func CreateTektonConfigWithProfileAndTargetNamespace(ctx context.Context, client
 			Profile: profile,
 			CommonSpec: tektonoperatorv1alpha1.CommonSpec{
 				TargetNamespace: targetNamepsace,
+			},
+			Pruner: tektonoperatorv1alpha1.Prune{
+				Disabled: false,
+				Keep:     &keep,
 			},
 		},
 	}

--- a/pkg/tekton/tekton_test.go
+++ b/pkg/tekton/tekton_test.go
@@ -153,6 +153,8 @@ func TestReconcileTekton(t *testing.T) {
 				g.Expect(tektonConfig.Name).To(o.Equal("config"))
 				g.Expect(tektonConfig.Spec.Profile).To(o.Equal("lite"))
 				g.Expect(tektonConfig.Spec.TargetNamespace).To(o.Equal("tekton-pipelines"))
+				g.Expect(tektonConfig.Spec.Pruner.Disabled).To(o.Equal(false))
+				g.Expect(tektonConfig.Spec.Pruner.Keep).NotTo(o.BeNil())
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

Starting in Tekton Operator v0.58.0, TektonConfig objects must set a value for `keep` or `keepSince` if the pruner is enabled [1]. If Shipwright bootstraps the TektonConfig object and does not set a value for `.spec.pruner.keep` (or `.keepSince`), it risks failing to reconcile the TektonConfig instance or worse [2].

Fixing by setting the `keep` value to match the Tekton operator default.

Fixes #231

[1] https://github.com/tektoncd/operator/pull/410
[2] https://github.com/tektoncd/operator/issues/2450

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
When the operator creates a TektonConfig object, enable the pruner with a default `keep` setting of 100.
```
