### PR TITLE
Fix: Add a check for tektonconfig status

### DIFF
--- a/controllers/buildstrategies_test.go
+++ b/controllers/buildstrategies_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Install embedded build strategies", func() {
 
 	BeforeEach(func(ctx SpecContext) {
 		setupTektonCRDs(ctx)
+		createTektonConfig(ctx)
 		build = createShipwrightBuild(ctx, "shipwright")
 		test.CRDEventuallyExists(ctx, k8sClient, "clusterbuildstrategies.shipwright.io")
 	})
@@ -43,6 +44,7 @@ var _ = Describe("Install embedded build strategies", func() {
 
 	AfterEach(func(ctx SpecContext) {
 		deleteShipwrightBuild(ctx, build)
+		deleteTektonConfig(ctx)
 	})
 
 })

--- a/controllers/default_test.go
+++ b/controllers/default_test.go
@@ -47,12 +47,13 @@ var _ = g.Describe("Reconcile default ShipwrightBuild installation", func() {
 	g.BeforeEach(func(ctx g.SpecContext) {
 		// setting up the namespaces, where Shipwright Controller will be deployed
 		setupTektonCRDs(ctx)
+		createTektonConfig(ctx)
 		build = createShipwrightBuild(ctx, targetNamespace)
 	})
 
 	g.AfterEach(func(ctx g.SpecContext) {
 		deleteShipwrightBuild(ctx, build)
-
+		deleteTektonConfig(ctx)
 		g.By("checking that the shipwright-build-controller deployment has been removed")
 		deployment := baseDeployment.DeepCopy()
 		test.EventuallyRemoved(ctx, k8sClient, deployment)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Added a check for tektonconfig before progressing in the reconciliation process.


Fixes #167


# Submitter Checklist

- [ x ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ x ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
```
Fix: build status reports ready early when tektonconfig is at Error/not available state
```
