### PR TITLE
Fixed Release Tag Format Bug

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
     env:
       IMAGE_HOST: ghcr.io
       IMAGE_NAMESPACE: ${{ github.repository }}
-      VERSION: ${{ inputs.release }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -37,6 +36,13 @@ jobs:
         cache: true
         check-latest: true
     - uses: sigstore/cosign-installer@v3
+    # removes v from release tag for VERSION env variable used by makefile command
+    - name: Derive version
+      env:
+        RELEASE_TAG: ${{ inputs.release }}
+      run: |
+        CLEAN="${RELEASE_TAG#v}"
+        echo "VERSION=${CLEAN}" >> "$GITHUB_ENV"
     - name: Build Release Images
       env:
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Changes
Release tag is expected in X.Y.Z format whereas previous tag is expected in vX.Y.Z format. The reason for this is that the release tag is used by Makefile command which expects version without leading v. However, this also creates the Github release tag without leading "v" in the actions/create-release step, which has to be manually edited in draft release note before publishing. This PR expects release tag in vX.Y.Z format and strips leading "v" before setting VERSION env.

Fixes #224 

# Release Notes
```release-note
NONE
```
