### PR TITLE
feat: Update minKubeVersion to v1.32.0

### DIFF
--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -777,7 +777,7 @@ spec:
   - email: shipwright-dev@lists.shipwright.io
     name: The Shipwright Contributors
   maturity: alpha
-  minKubeVersion: 1.31.0
+  minKubeVersion: 1.32.0
   provider:
     name: The Shipwright Contributors
     url: https://shipwright.io

--- a/config/manifests/bases/shipwright-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/shipwright-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ spec:
   - email: shipwright-dev@lists.shipwright.io
     name: The Shipwright Contributors
   maturity: alpha
-  minKubeVersion: 1.31.0
+  minKubeVersion: 1.32.0
   provider:
     name: The Shipwright Contributors
     url: https://shipwright.io


### PR DESCRIPTION
# Changes

Update the minimum Kubernetes version to 1.32.0 in the operator bundle 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE



# Release Notes

```release-note
Updated minimum supported k8s version to v1.32.8
```
