### PR TITLE
feat: Remove API Dependency on Tekton and cert-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ Once OLM has been deployed, use the following command to install the latest oper
 $ kubectl apply -f https://operatorhub.io/install/shipwright-operator.yaml
 ```
 
-## OLM Dependencies
-When installed via OLM using the provided Shipwright Operator Bundle, the Shipwright operator will ask OLM to deploy the following operators:
-- The [Tekton operator](https://tekton.dev/docs/operator/) to deploy and manage Tekton Pipelines.
-- The [Cert-Manager operator](https://cert-manager.io/docs/installation/operator-lifecycle-manager/) to provision certificates for admission/conversion webhooks.
-For this to work, the Shipwright operator must be included in a catalog that includes these other operators.
+## Prerequisites
+
+Before installing the Shipwright operator, you must have the following components installed in your cluster:
+
+- **Tekton**: The Shipwright operator requires Tekton Pipelines to be installed. Follow the [Tekton installation instructions](https://tekton.dev/docs/setup/) to install Tekton in your cluster.
+- **cert-manager**: The Shipwright operator uses cert-manager to provision certificates for admission/conversion webhooks. Follow the [cert-manager installation instructions](https://cert-manager.io/docs/installation/) to install cert-manager in your cluster.
+
+**Note**: The cert-manager operator has been deprecated. Please install cert-manager directly using the recommended installation method from the [cert-manager documentation](https://cert-manager.io/docs/installation/).
 
 ## Usage
 

--- a/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/shipwright-operator.clusterserviceversion.yaml
@@ -36,17 +36,16 @@ spec:
       kind: ShipwrightBuild
       name: shipwrightbuilds.operator.shipwright.io
       version: v1alpha1
-    required:
-    - kind: TektonConfig
-      name: tektonconfigs.operator.tekton.dev
-      version: v1alpha1
-    - kind: Certificate
-      name: certificates.cert-manager.io
-      version: v1
   description: |
     Shipwright is a framework for building container images on Kubernetes.
 
     Read more: [https://shipwright.io](https://shipwright.io)
+
+    ## Prerequisites
+
+    Before installing the Shipwright operator, ensure the following components are installed:
+    - **Tekton**: Follow the [Tekton installation instructions](https://tekton.dev/docs/setup/) to install Tekton Pipelines.
+    - **cert-manager**: Follow the [cert-manager installation instructions](https://cert-manager.io/docs/installation/) to install cert-manager for webhook certificate provisioning.
 
     ## Usage
 

--- a/config/manifests/bases/shipwright-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/shipwright-operator.clusterserviceversion.yaml
@@ -22,17 +22,16 @@ spec:
       kind: ShipwrightBuild
       name: shipwrightbuilds.operator.shipwright.io
       version: v1alpha1
-    required:
-    - kind: TektonConfig
-      name: tektonconfigs.operator.tekton.dev
-      version: v1alpha1
-    - kind: Certificate
-      name: certificates.cert-manager.io
-      version: v1
   description: |
     Shipwright is a framework for building container images on Kubernetes.
 
     Read more: [https://shipwright.io](https://shipwright.io)
+
+    ## Prerequisites
+
+    Before installing the Shipwright operator, ensure the following components are installed:
+    - **Tekton**: Follow the [Tekton installation instructions](https://tekton.dev/docs/setup/) to install Tekton Pipelines.
+    - **cert-manager**: Follow the [cert-manager installation instructions](https://cert-manager.io/docs/installation/) to install cert-manager for webhook certificate provisioning.
 
     ## Usage
 


### PR DESCRIPTION
# Changes

- Removed TektonConfig and cert-manager API dependencies from CSV files
- Updated documentation
- Fixed unit tests: Added CRD establishment wait and Switched to controller-runtime client
- Updated the e2e test script (hack/run-operator-catalog.sh) to install Tekton and cert-manager before creating the ShipwrightBuild.

#270 


# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE


# Release Notes
```release-note
Removed TektonConfig and cert-manager OLM dependencies
```
