### PR TITLE
fix: Update Tekton Manifests URL

### DIFF
--- a/hack/run-operator-catalog.sh
+++ b/hack/run-operator-catalog.sh
@@ -91,9 +91,9 @@ function install_tekton() {
     # Can be overridden via TEKTON_OPERATOR_VERSION env var
     TEKTON_OPERATOR_VERSION=${TEKTON_OPERATOR_VERSION:-v0.77.0}
     echo "Installing Tekton Operator version ${TEKTON_OPERATOR_VERSION}"
-    if ! ${KUBECTL_BIN} apply -f "https://storage.googleapis.com/tekton-releases/operator/previous/${TEKTON_OPERATOR_VERSION}/release.yaml"; then
+    if ! ${KUBECTL_BIN} apply -f "https://infra.tekton.dev/tekton-releases/operator/previous/${TEKTON_OPERATOR_VERSION}/release.yaml"; then
         echo "Warning: Failed to install Tekton Operator ${TEKTON_OPERATOR_VERSION}, falling back to latest"
-        ${KUBECTL_BIN} apply -f "https://storage.googleapis.com/tekton-releases/operator/latest/release.yaml"
+        ${KUBECTL_BIN} apply -f "https://infra.tekton.dev/tekton-releases/operator/latest/release.yaml"
     fi
     
     echo "Waiting for Tekton Operator to be ready"


### PR DESCRIPTION
# Changes

Update Tekton artifact hosting to `infra.tekton.dev`

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Update Tekton operator manifests url to `infra.tekton.dev`
```
