### PR TITLE
fix[ci]: update create-release action with gh cli

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,12 +71,13 @@ jobs:
         "${GITHUB_WORKSPACE}/.github/draft_release_notes.sh"
     - name: Draft release
       id: draft_release
-      uses: actions/create-release@v1
-      with:
-        release_name: ${{ inputs.release }}
-        tag_name: ${{ inputs.release }}
-        draft: true
-        prerelease: true
-        body_path: Changes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${{ inputs.release }}" \
+          --repo "${{ github.repository }}" \
+          --title "${{ inputs.release }}" \
+          --notes-file Changes.md \
+          --draft \
+          --prerelease \
+          --target ${{ inputs.git-ref }}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes #166 

This PR removes the use of depreceated action `actions/create-release` and adds `gh cli` to create releases

reason for choosing gh cli over another action:
-  zero install time
- this issue of actions going unmaintained won't happen again

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
