### PR TITLE
docs: remove shell prompts from command blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Before installation, ensure that OLM has been deployed on your cluster by follow
 Once OLM has been deployed, use the following command to install the latest operator release from [operatorhub.io](https://operatorhub.io/operator/shipwright-operator):
 
 ```sh
-$ kubectl apply -f https://operatorhub.io/install/shipwright-operator.yaml
+kubectl apply -f https://operatorhub.io/install/shipwright-operator.yaml
 ```
 
 ## Prerequisites

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -38,21 +38,21 @@ To test the operator on a Kubernetes cluster, you first must have the following:
 * Install [Tekton operator](https://github.com/tektoncd/operator) v0.74.0 or higher on the cluster.
 
 ```bash
-$ export KUBECONFIG=/path/to/kubeconfig
-$ kubectl apply -f https://github.com/tektoncd/operator/releases/download/v0.74.0/release.notags.yaml
+export KUBECONFIG=/path/to/kubeconfig
+kubectl apply -f https://github.com/tektoncd/operator/releases/download/v0.74.0/release.notags.yaml
 ```
 
 If pushing to an external image registry, you may need to provide credentials to ko:
 
 ```bash
-$ make ko
-$ ko login <IMAGE_REGISTRY> -u <USERNAME> -p <PASSWORD>
+make ko
+ko login <IMAGE_REGISTRY> -u <USERNAME> -p <PASSWORD>
 ```
 
 Next, use the `make deploy` command with appropriate `IMAGE_REPO` and `VERSION` arguments to deploy the operator to the cluster.
 
 ```bash
-$ make deploy IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" VERSION="<VERSION>"
+make deploy IMAGE_REPO="<IMAGE_REGISTRY>/<USERNAME>" VERSION="<VERSION>"
 ```
 
 _Note:_
@@ -60,5 +60,5 @@ _Note:_
 Scripts in `hack` folder may require `sed` (GNU), therefore in platforms other than Linux you may have it with a different name. For instance, on macOS it's usually named `gsed`, in this case provide the `SED_BIN` make variable with the alternative name.
 
 ```bash
-$ make build SED_BIN=gsed ...
+make build SED_BIN=gsed ...
 ```

--- a/docs/development/olm-development.md
+++ b/docs/development/olm-development.md
@@ -66,8 +66,8 @@ Like Step 2 above, you will need to publish a catalog containing the candidate o
 Run the following command to set the correct `BUNDLE_IMG` for the catalog:
 
 ```sh
-$ version=<version to test, no leading v> # example: 0.13.0-rc0
-$ make catalog-push IMAGE_REPO=<your-registry> VERSION="$version" BUNDLE_IMG="ghcr.io/shipwright-io/operator/operator-bundle:v$version"
+version=<version to test, no leading v> # example: 0.13.0-rc0
+make catalog-push IMAGE_REPO=<your-registry> VERSION="$version" BUNDLE_IMG="ghcr.io/shipwright-io/operator/operator-bundle:v$version"
 ```
 
 ### Step 2: Deploy the operator
@@ -75,8 +75,8 @@ $ make catalog-push IMAGE_REPO=<your-registry> VERSION="$version" BUNDLE_IMG="gh
 Similar to Step 3 above, deploy the operator with the catalog image:
 
 ```sh
-$ version=<version to test, no leading `v`> # example: 0.13.0-rc0
-$ make catalog-run IMAGE_REPO=<your-registry> VERSION="$version"
+version=<version to test, no leading `v`> # example: 0.13.0-rc0
+make catalog-run IMAGE_REPO=<your-registry> VERSION="$version"
 ```
 
 ## Troubleshooting
@@ -88,7 +88,7 @@ On platforms other than Linux, use the `SED_BIN` make variable to use a differen
 For instance, on MacOS sed functions are provided by `gsed`:
 
 ```bash
-$ make catalog-run SED_BIN=gsed ...
+make catalog-run SED_BIN=gsed ...
 ```
 
 ### Catalog Source Fails - Cannot Access Registry Over grpc
@@ -100,6 +100,6 @@ To fall back to HTTP-based pull, set the `USE-HTTP` make variable to `true` when
 the test catalog:
 
 ```bash
-$ make catalog-push USE-HTTP="true" ...
-$ make catalog-run ...
+make catalog-push USE-HTTP="true" ...
+make catalog-run ...
 ```

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -94,7 +94,7 @@ The OperatorHub release script requires the following:
 3. Add the community operators repository as the `upstream` remote:
 
    ```sh
-   $ git remote add upstream https://github.com/k8s-operatorhub/community-operators.git
+   git remote add upstream https://github.com/k8s-operatorhub/community-operators.git
    ```
 
 4. Install the [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)


### PR DESCRIPTION
## Description

Removes the unnecessary leading `$ ` shell prompts from command blocks throughout the documentation.

These prompts are especially annoying in click-to-copy blocks because the `$` can be copied as part of the command.

### Changes

* Removed leading `$ ` prompts from command examples in:

  * `README.md`
  * `docs/development/local-development.md`
  * `docs/development/olm-development.md`
  * `docs/development/releasing.md`
* Preserved actual shell variable syntax such as `$version` and `${...}`.

Closes #295

```release-note
NONE
```